### PR TITLE
Fixed MPI prtcl bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,20 +16,21 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 ##################################################
 # optimization flags
 
+#--------------------------------------------------
 # debug mode (default for code development)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g2 -O2 -DDEBUG -march=native -ftree-vectorize -fopt-info-all-all=all.all -Wall -Wextra -pedantic -Wno-error=unknown-pragmas -Wno-error=unused-parameter -save-temps=obj")
+#set(CMAKE_CXX_FLAGS_DEBUG "-g2 -O2 -DDEBUG -march=native -ftree-vectorize -fopt-info-all-all=all.all -Wall -Wextra -pedantic -Wno-error=unknown-pragmas -Wno-error=unused-parameter -save-temps=obj")
 #set(CMAKE_CXX_FLAGS_DEBUG "-g3 -O2 -DDEBUG -march=native -ftree-vectorize -Wall -Wextra -pedantic")
-#set(CMAKE_CXX_FLAGS_DEBUG "-g -O2 -DDEBUG -march=native -ftree-vectorize")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O2 -DDEBUG -march=native -ftree-vectorize")
 
 #--------------------------------------------------
-#set(CMAKE_CXX_FLAGS_RELEASE "-O2 -march=native -ftree-vectorize -fopt-info-all-all=all.all") general
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -march=native -mtune=native -ftree-vectorize")
-#set(CMAKE_CXX_FLAGS_RELEASE "-O2 -march=znver1 -mtune=znver1 -mfma -mavx2 -m3dnow -flto=auto -fomit-frame-pointer -fopt-info-all-all=all.all")
-#set(CMAKE_CXX_FLAGS_RELEASE "-O2 -march=znver1 -mtune=znver1 -flto=auto -fomit-frame-pointer -fopt-info-all-all=all.all")
+# release mode flags
 
-# epyc rome
-#set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=znver1 -mtune=znver1 -mfma -mavx2 -m3dnow -fomit-frame-pointer -fopt-info-all-all=all.all")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fopenmp") # common gcc
+#set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -flto -ffp=4 -march=znver3 -mtune=znver3 -fopenmp -fsave-loopmark") // cray compiler flags
+#set(CMAKE_CXX_FLAGS_RELEASE "-O2 -march=znver3 -mtune=znver3 -ftree-vectorize") # epyc rome
+#set(CMAKE_CXX_FLAGS_RELEASE "-O2 -march=znver1 -mtune=znver1 -mfma -mavx2 -m3dnow -flto=auto -fomit-frame-pointer -fopt-info-all-all=all.all") #rome w/ output
+
 
 #--------------------------------------------------
 # other compiliation modes

--- a/core/pic/boundaries/piston.c++
+++ b/core/pic/boundaries/piston.c++
@@ -106,7 +106,7 @@ void pic::Piston<D>::solve(
 {
 
   // outflowing particles
-  std::vector<int> to_be_deleted;
+  //std::vector<int> to_be_deleted;
 
   // skip if piston head is not inside tile boundaries
   auto mins = tile.mins;
@@ -116,7 +116,7 @@ void pic::Piston<D>::solve(
 
 
   for(auto&& container : tile.containers) {
-    to_be_deleted.clear();
+    //to_be_deleted.clear();
 
     const double c = tile.cfl;
     const double q = container.q;
@@ -148,7 +148,9 @@ void pic::Piston<D>::solve(
         // check if this is reflected particle; else remove 
         // equals to right boundary outflow as they wrap particles to here
         if(walloc0 - x0 > c) {
-          to_be_deleted.push_back(n);
+          //to_be_deleted.push_back(n);
+          container.loc(0,n) =  1; // insert prtcl behind wall
+          container.info(n)  = -1; // insert prtcl behind wall
           continue;
         }
 
@@ -160,7 +162,10 @@ void pic::Piston<D>::solve(
 
         // skip this particle since it is further away from the wall than one time step
         if(dt > 1.0) {
-          to_be_deleted.push_back(n);
+          //to_be_deleted.push_back(n);
+
+          container.loc(0,n) =  1; // insert prtcl behind wall
+          container.info(n)  = -2; // insert prtcl behind wall
           continue; 
         }
 
@@ -217,7 +222,8 @@ void pic::Piston<D>::solve(
     }
 
     // process outflown particles
-    container.delete_particles(to_be_deleted);
+    //container.delete_particles(to_be_deleted);
+    container.delete_transferred_particles(); // delete via infoArr status (-1 or -2)
 
   } // end of loop over species
 }

--- a/core/pic/boundaries/piston_z.c++
+++ b/core/pic/boundaries/piston_z.c++
@@ -312,13 +312,7 @@ void pic::PistonZdir<D>::clean_prtcls( pic::Tile<D>& tile)
   // if wall crossing is not inside tile, skip further analysis
   if( !tile_between_z ) return;
 
-  // outflowing particles
-  std::vector<int> to_be_deleted;
-
-
   for(auto&& con : tile.containers) {
-    //const auto c = tile.cfl;    // speed of light
-    to_be_deleted.clear();
 
     for(size_t n=0; n<con.size(); n++) {
 
@@ -330,10 +324,12 @@ void pic::PistonZdir<D>::clean_prtcls( pic::Tile<D>& tile)
       if( wdir < 0.0 && z1 > wallocz ) behind_wall = true;
 
       // skip if we dont reflect
-      if(behind_wall) to_be_deleted.push_back(n);
+      if(behind_wall) {
+        con.info(n) = -1; // mark for deletion
+      }
     }
 
-    con.delete_particles(to_be_deleted);
+    con.delete_transferred_particles();
   }
 
 }

--- a/core/pic/boundaries/star_surface_injector.c++
+++ b/core/pic/boundaries/star_surface_injector.c++
@@ -486,9 +486,9 @@ void pic::Star<D>::solve(
 
 
   // call pre-iteration functions to update internal arrays 
-  for(auto&& con : tile.containers) {
-      con.to_other_tiles.clear(); // empty tmp container; we store killed particles here
-  }
+  //for(auto&& con : tile.containers) {
+  //    con.to_other_tiles.clear(); // empty tmp container; we store killed particles here
+  //}
 
 
   for(auto&& con : tile.containers) {
@@ -542,7 +542,8 @@ void pic::Star<D>::solve(
           inside_cyl_bcs              || 
           (top && inside_top)              // particles at the very top
           ) {
-        con.to_other_tiles.push_back( {1,1,1,n} );
+        //con.to_other_tiles.push_back( {1,1,1,n} );
+        con.info(n) = -1;
       }
     }
   }

--- a/core/pic/depositers/zigzag.c++
+++ b/core/pic/depositers/zigzag.c++
@@ -84,13 +84,13 @@ void pic::ZigZag<D,V>::solve( pic::Tile<D>& tile )
       //--------------------------------------------------
       // +q since - sign is already included in the Ampere's equation
       //q = weight*qe;
-      double Fx1 = +q*(xr - x1);
-      double Fy1 = +q*(yr - y1);
-      double Fz1 = +q*(zr - z1);
+      double Fx1 = +q*con.wgt(n)*(xr - x1);
+      double Fy1 = +q*con.wgt(n)*(yr - y1);
+      double Fz1 = +q*con.wgt(n)*(zr - z1);
       
-      double Fx2 = +q*(x2 - xr);
-      double Fy2 = +q*(y2 - yr);
-      double Fz2 = +q*(z2 - zr);
+      double Fx2 = +q*con.wgt(n)*(x2 - xr);
+      double Fy2 = +q*con.wgt(n)*(y2 - yr);
+      double Fz2 = +q*con.wgt(n)*(z2 - zr);
 
 
       double Wx1 = D >= 1 ? 0.5*(x1 + xr) - i1 : 0.0;
@@ -106,21 +106,25 @@ void pic::ZigZag<D,V>::solve( pic::Tile<D>& tile )
      // check outflow
 
       // debug guard
-      if( i1 < -3 || i1 + 1 > maxs[0] + 2 ||
-          i2 < -3 || i2 + 1 > maxs[0] + 2 ||
-          j1 < -3 || j1 + 1 > maxs[1] + 2 ||
-          j2 < -3 || j2 + 1 > maxs[1] + 2 ||
-          k1 < -3 || k1 + 1 > maxs[2] + 2 ||
-          k2 < -3 || k2 + 1 > maxs[2] + 2) {
+      const int H = 3;
+      if((i1 < -H || i1 >= maxs[0] + H-1 ||
+          i2 < -H || i2 >= maxs[0] + H-1 ||
+          j1 < -H || j1 >= maxs[1] + H-1 ||
+          j2 < -H || j2 >= maxs[1] + H-1 ||
+          k1 < -H || k1 >= maxs[2] + H-1 ||
+          k2 < -H || k2 >= maxs[2] + H-1 ) && 
+          con.wgt(n) > 0.0) {
 
-        std::cerr << "ERROR ZIGZAG:" << std::endl;
-        std::cerr << " i1 " << i1 << " i2 " << i2;
-        std::cerr << " j1 " << j1 << " j2 " << j2;
-        std::cerr << " k1 " << k1 << " k2 " << k2;
-        std::cerr << " x1 " << x1 << " x2 " << x2;
-        std::cerr << " y1 " << y1 << " y2 " << y2;
-        std::cerr << " z1 " << z1 << " z2 " << z2;
-        std::cerr << " v " << u << " " << v << " " << w << std::endl;
+        std::cerr << "ERROR ZIGZAG:" 
+                  << " i1 " << i1 << " i2 " << i2
+                  << " j1 " << j1 << " j2 " << j2
+                  << " k1 " << k1 << " k2 " << k2
+                  << " x1 " << x1 << " x2 " << x2
+                  << " y1 " << y1 << " y2 " << y2
+                  << " z1 " << z1 << " z2 " << z2
+                  << " v " << u << " " << v << " " << w 
+                  << " wgt " << con.wgt(n) << " info " << con.info(n) 
+                  << std::endl;
 
         // do not deposit anything
         Fx1 = 0.0, Fx2 = 0.0, Fy1 = 0.0, Fy2 = 0.0, Fz1 = 0.0, Fz2 = 0.0;

--- a/core/pic/depositers/zigzag.c++
+++ b/core/pic/depositers/zigzag.c++
@@ -125,7 +125,7 @@ void pic::ZigZag<D,V>::solve( pic::Tile<D>& tile )
         // do not deposit anything
         Fx1 = 0.0, Fx2 = 0.0, Fy1 = 0.0, Fy2 = 0.0, Fz1 = 0.0, Fz2 = 0.0;
         i1=0, i2=0, j1=0, j2=0, k1=0, k2=0;
-        assert(false);
+        //assert(false);
       }
 
       //--------------------------------------------------

--- a/core/pic/depositers/zigzag.c++
+++ b/core/pic/depositers/zigzag.c++
@@ -112,8 +112,8 @@ void pic::ZigZag<D,V>::solve( pic::Tile<D>& tile )
           j1 < -H || j1 >= maxs[1] + H-1 ||
           j2 < -H || j2 >= maxs[1] + H-1 ||
           k1 < -H || k1 >= maxs[2] + H-1 ||
-          k2 < -H || k2 >= maxs[2] + H-1 ) && 
-          con.wgt(n) > 0.0) {
+          k2 < -H || k2 >= maxs[2] + H-1 ) ){
+          //&& con.wgt(n) > 0.0) {
 
         std::cerr << "ERROR ZIGZAG:" 
                   << " i1 " << i1 << " i2 " << i2

--- a/core/pic/depositers/zigzag.c++
+++ b/core/pic/depositers/zigzag.c++
@@ -102,10 +102,11 @@ void pic::ZigZag<D,V>::solve( pic::Tile<D>& tile )
       double Wz2 = D >= 3 ? 0.5*(z2 + zr) - k2 : 0.0;
 
 
+
      //-------------------------------------------------- 
      // check outflow
-
-      // debug guard
+#if DEBUG
+       
       const int H = 3;
       if((i1 < -H || i1 >= maxs[0] + H-1 ||
           i2 < -H || i2 >= maxs[0] + H-1 ||
@@ -131,6 +132,7 @@ void pic::ZigZag<D,V>::solve( pic::Tile<D>& tile )
         i1=0, i2=0, j1=0, j2=0, k1=0, k2=0;
         //assert(false);
       }
+#endif
 
       //--------------------------------------------------
       // one-dimensional indices

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -680,17 +680,11 @@ void ParticleContainer<D>::delete_transferred_particles()
     auto [i,j,k] = info2dir(n);
 
     bool inside_tile = (i == 0) && (j == 0) && (k == 0);
-    //if(n == 0) inside_tile = true; // special case of new/transferred particle
-
     bool to_be_removed = !inside_tile;
 
-    //std::cout << "  in del: n: " << n << " ijk " << i << "," << j << "," << k << " wgt: " << wgtArr[n] << " in " << inside_tile <<  "\n";
-
+    // replace good value with a bad value
     if( !to_be_removed ) {
       if( iter != first ){
-
-        //std::cout << "remove_if: first:" << first << " res " << iter << " last " << last << " n: " << n << "\n";
-        //std::cout << "            locs:" << locn[0][iter] << "swamp <= " << locn[0][first] << "\n";
 
         // should be move operation; same?
         locn[0][iter] = locn[0][first];
@@ -713,88 +707,12 @@ void ParticleContainer<D>::delete_transferred_particles()
   }
   int new_last = iter;
 
-
-
-  // libc implementation
-  // __first = std::find_if<_ForwardIterator, _Predicate&>(__first, __last, __pred);
-  //  if (__first != __last) {
-  //    _ForwardIterator __i = __first;
-  //    while (++__i != __last) {
-  //      if (!__pred(*__i)) {
-  //        *__first = std::move(*__i);
-  //        ++__first;
-  //      }
-  //    }
-  //  }
-  //  return __first;
-  //}
-
-
-  //--------------------------------------------------
-  // remove_if idiom
-  //int first = 0;
-  //int last = size();
-
-  //for(;first<last;first++){
-  //  
-  //  // check if outside tile 
-  //  int n = infoArr[first];
-  //  auto [i,j,k] = info2dir(n);
-
-  //  bool inside_tile = (i == 0) && (j == 0) && (k == 0);
-  //  bool to_be_removed = !inside_tile;
-  //  if(to_be_removed) break;
-  //}
-
-  //int iter = first;
-  //while(++iter != last){
-
-  //  // check if outside tile 
-  //  int n = infoArr[iter];
-  //  auto [i,j,k] = info2dir(n);
-
-  //  bool inside_tile = (i == 0) && (j == 0) && (k == 0);
-  //  bool to_be_removed = !inside_tile;
-
-  //  std::cout << "  test:" 
-  //    << " first:" << first
-  //    << " iter:"  << iter
-  //    << " del:"  << to_be_removed
-  //    << " \n";
-
-  //  if(!to_be_removed){
-  //      locn[0][first] = locn[0][iter];
-  //      locn[1][first] = locn[1][iter];
-  //      locn[2][first] = locn[2][iter];
-
-  //      veln[0][first] = veln[0][iter];
-  //      veln[1][first] = veln[1][iter];
-  //      veln[2][first] = veln[2][iter];
-
-  //      idn[0][ first] =  idn[0][iter];
-  //      idn[1][ first] =  idn[1][iter];
-
-  //      wgtArr[ first] =  wgtArr[iter];
-  //      infoArr[first] = infoArr[iter];
-  //      
-  //      std::cout << "     del:" 
-  //        << " first:" << first
-  //        << " to iter:" << iter
-  //        << "\n";
-
-  //      ++first;
-  //  }
-  //}
-  //int new_last = first;
-
   //--------------------------------------------------
   //for(int n=0; n<size(); n++){
   //  int nn = infoArr[n];
   //  auto [i,j,k] = info2dir(nn);
-
   //  std::cout << "list after del: n: " << n << " ind: " << nn << " ijk " << i << "," << j << "," << k << " wgt: " << wgtArr[n] << "\n";
   //}
-
 
   // now remove anything between result and last
   resize(new_last);

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -833,6 +833,15 @@ void ParticleContainer<D>::transfer_and_wrap_particles(
   nvtxRangePush(__PRETTY_FUNCTION__);
 #endif
 
+  // global grid limits
+  const float minx = global_mins[0];
+  const float miny = global_mins[1];
+  const float minz = global_mins[2];
+
+  const float maxx = global_maxs[0];
+  const float maxy = global_maxs[1];
+  const float maxz = global_maxs[2];
+
   //--------------------------------------------------
   // v2: loop w/o external to_other_tiles storage
 
@@ -852,9 +861,9 @@ void ParticleContainer<D>::transfer_and_wrap_particles(
     if( (D==3) && (i== -dirs[0]) && (j==-dirs[1]) && (k==-dirs[2]) ) add = true;
     
     if(add) {
-      float locx = wrap( neigh.loc(0, n), static_cast<float>(global_mins[0]), static_cast<float>(global_maxs[0]) );
-      float locy = wrap( neigh.loc(1, n), static_cast<float>(global_mins[1]), static_cast<float>(global_maxs[1]) );
-      float locz = wrap( neigh.loc(2, n), static_cast<float>(global_mins[2]), static_cast<float>(global_maxs[2]) );
+      float locx = wrap( neigh.loc(0, n), minx, maxx );
+      float locy = wrap( neigh.loc(1, n), miny, maxy );
+      float locz = wrap( neigh.loc(2, n), minz, maxz );
 
       add_identified_particle(
           {locx, locy, locz}, 
@@ -1065,7 +1074,7 @@ void ParticleContainer<D>::pack_outgoing_particles()
 
 
   // first particle is always the message info
-  outgoing_particles[0] =       {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, np_tot, 0}; // store prtcl number in id slot
+  outgoing_particles[0] =       {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, np_tot,   0}; // store prtcl number in id slot
   outgoing_extra_particles[0] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, np_extra, 0}; // store prtcl number in id slot
                                                                               
   // -------------------------------------------------- 
@@ -1186,6 +1195,7 @@ void ParticleContainer<D>::unpack_incoming_particles()
   // skipping 1st info particle
   for(int i=1; i<number_of_primary_particles; i++){
     //std::cout << "inserting1 to slot" << N+i-1 << " out of " << N << "\n";
+
     locx = incoming_particles[i].x;
     locy = incoming_particles[i].y;
     locz = incoming_particles[i].z;

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -210,7 +210,6 @@ void ParticleContainer<D>::add_identified_particle (
   assert(!std::isnan(_proc));
 #endif
 
-
   for (size_t i=0; i<3; i++) locArr[i].push_back(prtcl_loc[i]);
   for (size_t i=0; i<3; i++) velArr[i].push_back(prtcl_vel[i]);
   wgtArr.push_back(prtcl_wgt);
@@ -488,7 +487,9 @@ std::array<double,3>& maxs)
     //if( loc(2,n) - float( maxs[2] ) >= 2.0 ) outflow = true; // front wrap
     
     //if( outflow ){
-    //  std::cout << " ERROR outflow " <<  
+    
+    //if ( (i != 0) || (j != 0) || (k != 0) ) {
+    //  std::cout << " outflow " <<  
     //    n << " " << 
     //    loc(0,n) << " " << 
     //    loc(1,n) << " " << 
@@ -499,6 +500,7 @@ std::array<double,3>& maxs)
     //    " mins:" << float(mins[0]) << " " << float(mins[1]) << " " << float(mins[2]) << 
     //    " maxs:" << float(maxs[0]) << " " << float(maxs[1]) << " " << float(maxs[2]) << 
     //    std::endl;
+    //}
     //    
     //  assert(!outflow);
     //}
@@ -679,7 +681,11 @@ void ParticleContainer<D>::delete_transferred_particles()
   int last = size()-to_other_tiles.size();
   //std::cout << "del: " << size() << " to be deleted: " << to_other_tiles.size() << std::endl;
   
-  UniIter::iterate([=] DEVCALLABLE (int ii, ManVec<to_other_tiles_struct> &to_other_tiles){
+
+  // NOTE vectorizing the below loop leads to race conditions; hence it is turned off for now
+    
+  //UniIter::iterate([=] DEVCALLABLE (int ii, ManVec<to_other_tiles_struct> &to_other_tiles){
+  for(int ii=0; ii<to_other_tiles.size(); ii++){
     int other = last+ii; //size() - 1 - i;
     int indx = to_other_tiles[ii].n;
 
@@ -687,12 +693,14 @@ void ParticleContainer<D>::delete_transferred_particles()
     //std::cout << " sw " << indx << " to " << other << " while last " << last << std::endl;
       
     //std::cout << "deleting " << indx << " by putting it to " << last << '\n';
+
     for(int i=0; i<3; i++) locn[i][indx] = locn[i][other];
     for(int i=0; i<3; i++) veln[i][indx] = veln[i][other];
     for(int i=0; i<2; i++) idn[ i][indx] = idn[ i][other];
-    wgtArr[indx] = wgtArr[other];
+    wgtArr[indx] = wgtArr[other]; 
 
-  }, to_other_tiles.size(), to_other_tiles);
+  }
+  //, to_other_tiles.size(), to_other_tiles);
   
   UniIter::sync();
   

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -982,7 +982,8 @@ void ParticleContainer<D>::pack_all_particles()
   }
 
   // first particle is always the message info
-  outgoing_particles[0] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, np, 0}; // store prtcl number in id slot
+  outgoing_particles[0]       = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, np, 0}; // store prtcl number in id slot
+  outgoing_extra_particles[0] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, np, 0}; // store prtcl number in id slot
 
   // next, pack all other particles
   int i=1;
@@ -995,6 +996,7 @@ void ParticleContainer<D>::pack_all_particles()
         wgt(ind), 
         id(0, ind), id(1, ind) };
     } else {
+      //outgoing_extra_particles.push_back({ 
       outgoing_extra_particles.push_back({ 
         loc(0, ind), loc(1, ind), loc(2, ind), 
         vel(0, ind), vel(1, ind), vel(2, ind), 
@@ -1020,7 +1022,7 @@ void ParticleContainer<D>::pack_outgoing_particles()
 #endif
 
   //outgoing_particles.clear();
-  outgoing_extra_particles.clear();
+  //outgoing_extra_particles.clear();
     
 
   int num_of_outgoing = 0;
@@ -1059,12 +1061,12 @@ void ParticleContainer<D>::pack_outgoing_particles()
   //  // reserve is needed here; if size is less than capacity, we do nothing
   //  outgoing_extra_particles.reserve( np_tot - first_message_size ); 
   //}
-  outgoing_extra_particles.reserve( np_extra );
+  outgoing_extra_particles.resize( np_extra );
 
 
   // first particle is always the message info
-  outgoing_particles[0] =            {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, np_tot, 0}; // store prtcl number in id slot
-  outgoing_extra_particles.push_back({0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, np_extra, 0}); // store prtcl number in id slot
+  outgoing_particles[0] =       {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, np_tot, 0}; // store prtcl number in id slot
+  outgoing_extra_particles[0] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, np_extra, 0}; // store prtcl number in id slot
                                                                               
   // -------------------------------------------------- 
   // v1 with on-the-fly calculation of escape condition
@@ -1089,11 +1091,13 @@ void ParticleContainer<D>::pack_outgoing_particles()
           wgt(n), 
           id(0, n), id(1, n) };
       } else {
-        outgoing_extra_particles.push_back({ 
+        int ind2 = ind - first_message_size + 1;
+        //outgoing_extra_particles.push_back({ 
+        outgoing_extra_particles[ind2] = {
           loc(0, n), loc(1, n), loc(2, n), 
           vel(0, n), vel(1, n), vel(2, n), 
           wgt(n), 
-          id(0, n), id(1, n) });
+          id(0, n), id(1, n) };
       }
       ind++;
     }

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -493,29 +493,29 @@ std::array<double,3>& maxs)
 
   // second pass to reconstruct to_other_tiles
   // TODO remove
-  //to_other_tiles.clear();
-  //to_other_tiles.reserve(outgoing_count);
-  //for(size_t n=0; n<size(); n++) {
+  to_other_tiles.clear();
+  to_other_tiles.reserve(outgoing_count);
+  for(size_t n=0; n<size(); n++) {
 
-  //  //int ii=0,jj=0,kk=0; // relative indices
-  //  //if( loc(0,n) - float( mins[0] ) <  0.0 ) ii--; // left wrap
-  //  //if( loc(0,n) - float( maxs[0] ) >= 0.0 ) ii++; // right wrap
-  //  //if( loc(1,n) - float( mins[1] ) <  0.0 ) jj--; // bottom wrap
-  //  //if( loc(1,n) - float( maxs[1] ) >= 0.0 ) jj++; // top wrap
-  //  //if( loc(2,n) - float( mins[2] ) <  0.0 ) kk--; // back wrap
-  //  //if( loc(2,n) - float( maxs[2] ) >= 0.0 ) kk++; // front wrap
+    //int ii=0,jj=0,kk=0; // relative indices
+    //if( loc(0,n) - float( mins[0] ) <  0.0 ) ii--; // left wrap
+    //if( loc(0,n) - float( maxs[0] ) >= 0.0 ) ii++; // right wrap
+    //if( loc(1,n) - float( mins[1] ) <  0.0 ) jj--; // bottom wrap
+    //if( loc(1,n) - float( maxs[1] ) >= 0.0 ) jj++; // top wrap
+    //if( loc(2,n) - float( mins[2] ) <  0.0 ) kk--; // back wrap
+    //if( loc(2,n) - float( maxs[2] ) >= 0.0 ) kk++; // front wrap
 
-  //  auto [i,j,k] = info2dir( infoArr[n] );
+    auto [i,j,k] = info2dir( infoArr[n] );
 
-  //  //std::cout << "comp " << 
-  //  //  " ijk v1: " <<i<<","<<j<<","<<k << " n:"<<n<<
-  //  //  " ijk v0: " <<ii<<","<<jj<<","<<kk
-  //  //  <<"\n";
-  //  
-  //  if ( (i != 0) || (j != 0) || (k != 0) ) {
-	//    to_other_tiles.push_back( {i,j,k,n} );
-  //  }
-  //}
+    //std::cout << "comp " << 
+    //  " ijk v1: " <<i<<","<<j<<","<<k << " n:"<<n<<
+    //  " ijk v0: " <<ii<<","<<jj<<","<<kk
+    //  <<"\n";
+    
+    if ( (i != 0) || (j != 0) || (k != 0) ) {
+	    to_other_tiles.push_back( {i,j,k,n} );
+    }
+  }
 
   //std::cout << "INFO " << cid << " outgoing count:" << outgoing_count << "\n";
 #endif
@@ -1035,58 +1035,59 @@ void ParticleContainer<D>::pack_outgoing_particles()
   // v1 with on-the-fly calculation of escape condition
 
   // next, pack all other particles
-  int ind=1;
-  for(int n=0; n<size(); n++){
+  //int ind=1;
+  //for(int n=0; n<size(); n++){
 
-    // check if moving out
-    auto [i,j,k] = info2dir( infoArr[n] );
-    bool inside_tile = (i == 0) && (j == 0) && (k == 0);
-    bool to_be_packed = !inside_tile;
+  //  // check if moving out
+  //  auto [i,j,k] = info2dir( infoArr[n] );
+  //  bool inside_tile = (i == 0) && (j == 0) && (k == 0);
+  //  bool to_be_packed = !inside_tile;
 
-    // pack if true; split between fixed primary and adaptive extra message containers
-    if(to_be_packed) {
-      if(ind < first_message_size) {
-        outgoing_particles.push_back({ 
-          loc(0, n), loc(1, n), loc(2, n), 
-          vel(0, n), vel(1, n), vel(2, n), 
-          wgt(n), 
-          id(0, n), id(1, n) });
-      } else {
-        outgoing_extra_particles.push_back({ 
-          loc(0, n), loc(1, n), loc(2, n), 
-          vel(0, n), vel(1, n), vel(2, n), 
-          wgt(n), 
-          id(0, n), id(1, n) });
-      }
-      ind++;
-    }
-  }
+  //  // pack if true; split between fixed primary and adaptive extra message containers
+  //  if(to_be_packed) {
+  //    if(ind < first_message_size) {
+  //      outgoing_particles.push_back({ 
+  //        loc(0, n), loc(1, n), loc(2, n), 
+  //        vel(0, n), vel(1, n), vel(2, n), 
+  //        wgt(n), 
+  //        id(0, n), id(1, n) });
+  //    } else {
+  //      outgoing_extra_particles.push_back({ 
+  //        loc(0, n), loc(1, n), loc(2, n), 
+  //        vel(0, n), vel(1, n), vel(2, n), 
+  //        wgt(n), 
+  //        id(0, n), id(1, n) });
+  //    }
+  //    ind++;
+  //  }
+  //}
 
   //std::cout << " inserted " << ind << "\n";
 
   // -------------------------------------------------- 
   // v0 with to_other_tiles 
-  //for (size_t ii = 0; ii < to_other_tiles.size(); ii++)
-  //{
-  //  const auto &elem = to_other_tiles[ii];
-  //  ind = elem.n;
+  int i = 1;
+  for (size_t ii = 0; ii < to_other_tiles.size(); ii++)
+  {
+    const auto &elem = to_other_tiles[ii];
+    int ind = elem.n;
 
-  //  if(i < first_message_size) {
-  //    outgoing_particles.push_back({ 
-  //      loc(0, ind), loc(1, ind), loc(2, ind), 
-  //      vel(0, ind), vel(1, ind), vel(2, ind), 
-  //      wgt(ind), 
-  //      id(0, ind), id(1, ind) });
-  //  } else {
-  //    outgoing_extra_particles.push_back({ 
-  //      loc(0, ind), loc(1, ind), loc(2, ind), 
-  //      vel(0, ind), vel(1, ind), vel(2, ind), 
-  //      wgt(ind), 
-  //      id(0, ind), id(1, ind) });
-  //  }
+    if(i < first_message_size) {
+      outgoing_particles.push_back({ 
+        loc(0, ind), loc(1, ind), loc(2, ind), 
+        vel(0, ind), vel(1, ind), vel(2, ind), 
+        wgt(ind), 
+        id(0, ind), id(1, ind) });
+    } else {
+      outgoing_extra_particles.push_back({ 
+        loc(0, ind), loc(1, ind), loc(2, ind), 
+        vel(0, ind), vel(1, ind), vel(2, ind), 
+        wgt(ind), 
+        id(0, ind), id(1, ind) });
+    }
 
-  //  i++;
-  //}
+    i++;
+  }
 
 
   // -------------------------------------------------- 

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -1180,8 +1180,8 @@ void ParticleContainer<D>::unpack_incoming_particles()
   //  << " seco:" << number_of_secondary_particles 
   //  << " N:"    << N << "\n"; 
 
-  //reserve( N + number_of_incoming_particles + number_of_secondary_particles );  //reserve for addition
-  resize( N + number_of_incoming_particles - 2 );  // resize for insertion
+  reserve( N + number_of_incoming_particles - 2 );  //reserve for addition
+  //resize( N + number_of_incoming_particles - 2 );  // resize for insertion
 
   // skipping 1st info particle
   for(int i=1; i<number_of_primary_particles; i++){
@@ -1198,11 +1198,11 @@ void ParticleContainer<D>::unpack_incoming_particles()
     ids  = incoming_particles[i].id;
     proc = incoming_particles[i].proc;
 
-    //add_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc);
-    insert_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc, N+i-1 );
+    add_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc);
+    //insert_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc, N+i-1 );
   }
 
-  N += number_of_primary_particles-1;
+  //N += number_of_primary_particles-1;
   for(int i=1; i<number_of_secondary_particles; i++){
     //std::cout << "inserting2 to slot" << N+i-1 << " out of " << N << "\n";
 
@@ -1218,12 +1218,12 @@ void ParticleContainer<D>::unpack_incoming_particles()
     ids  = incoming_extra_particles[i].id;
     proc = incoming_extra_particles[i].proc;
       
-    //add_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc);
-    insert_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc, N+i-1);
+    add_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc);
+    //insert_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc, N+i-1);
   }
 
   // update internal counter after insertion
-  Nprtcls += number_of_incoming_particles-2;
+  //Nprtcls += number_of_incoming_particles-2;
 
 
 #ifdef GPU

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -493,29 +493,29 @@ std::array<double,3>& maxs)
 
   // second pass to reconstruct to_other_tiles
   // TODO remove
-  to_other_tiles.clear();
-  to_other_tiles.reserve(outgoing_count);
-  for(size_t n=0; n<size(); n++) {
+  //to_other_tiles.clear();
+  //to_other_tiles.reserve(outgoing_count);
+  //for(size_t n=0; n<size(); n++) {
 
-    //int ii=0,jj=0,kk=0; // relative indices
-    //if( loc(0,n) - float( mins[0] ) <  0.0 ) ii--; // left wrap
-    //if( loc(0,n) - float( maxs[0] ) >= 0.0 ) ii++; // right wrap
-    //if( loc(1,n) - float( mins[1] ) <  0.0 ) jj--; // bottom wrap
-    //if( loc(1,n) - float( maxs[1] ) >= 0.0 ) jj++; // top wrap
-    //if( loc(2,n) - float( mins[2] ) <  0.0 ) kk--; // back wrap
-    //if( loc(2,n) - float( maxs[2] ) >= 0.0 ) kk++; // front wrap
+  //  //int ii=0,jj=0,kk=0; // relative indices
+  //  //if( loc(0,n) - float( mins[0] ) <  0.0 ) ii--; // left wrap
+  //  //if( loc(0,n) - float( maxs[0] ) >= 0.0 ) ii++; // right wrap
+  //  //if( loc(1,n) - float( mins[1] ) <  0.0 ) jj--; // bottom wrap
+  //  //if( loc(1,n) - float( maxs[1] ) >= 0.0 ) jj++; // top wrap
+  //  //if( loc(2,n) - float( mins[2] ) <  0.0 ) kk--; // back wrap
+  //  //if( loc(2,n) - float( maxs[2] ) >= 0.0 ) kk++; // front wrap
 
-    auto [i,j,k] = info2dir( infoArr[n] );
+  //  auto [i,j,k] = info2dir( infoArr[n] );
 
-    //std::cout << "comp " << 
-    //  " ijk v1: " <<i<<","<<j<<","<<k << " n:"<<n<<
-    //  " ijk v0: " <<ii<<","<<jj<<","<<kk
-    //  <<"\n";
-    
-    if ( (i != 0) || (j != 0) || (k != 0) ) {
-	    to_other_tiles.push_back( {i,j,k,n} );
-    }
-  }
+  //  //std::cout << "comp " << 
+  //  //  " ijk v1: " <<i<<","<<j<<","<<k << " n:"<<n<<
+  //  //  " ijk v0: " <<ii<<","<<jj<<","<<kk
+  //  //  <<"\n";
+  //  
+  //  if ( (i != 0) || (j != 0) || (k != 0) ) {
+	//    to_other_tiles.push_back( {i,j,k,n} );
+  //  }
+  //}
 
   //std::cout << "INFO " << cid << " outgoing count:" << outgoing_count << "\n";
 #endif
@@ -1017,7 +1017,7 @@ void ParticleContainer<D>::pack_outgoing_particles()
   //int np = to_other_tiles.size() + 1;
 
   // DEBUG
-  assert(to_other_tiles.size() == outgoing_count );
+  //assert(to_other_tiles.size() == outgoing_count );
 
   //std::cout << "outgoing prtcls: " << outgoing_count << " vs " << to_other_tiles.size() << "\n";
   //std::cout << "reserving1: " << first_message_size << "\n";

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -1130,8 +1130,8 @@ void ParticleContainer<D>::unpack_incoming_particles()
   //          << " seco:" << number_of_secondary_particles 
   //          << " N:"    << N << "\n"; 
 
-  //reserve( N + number_of_incoming_particles + number_of_secondary_particles );  //reserve for addition
-  resize( N + number_of_incoming_particles );  // resize for insertion
+  reserve( N + number_of_incoming_particles + number_of_secondary_particles );  //reserve for addition
+  //resize( N + number_of_incoming_particles );  // resize for insertion
 
   // skipping 1st info particle
   for(int i=1; i<number_of_primary_particles; i++){
@@ -1147,8 +1147,8 @@ void ParticleContainer<D>::unpack_incoming_particles()
     ids  = incoming_particles[i].id;
     proc = incoming_particles[i].proc;
 
-    //add_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc);
-    insert_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc, N+i-1 );
+    add_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc);
+    //insert_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc, N+i-1 );
   }
 
   N += number_of_primary_particles-1;
@@ -1165,12 +1165,12 @@ void ParticleContainer<D>::unpack_incoming_particles()
     ids  = incoming_extra_particles[i].id;
     proc = incoming_extra_particles[i].proc;
       
-    //add_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc);
-    insert_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc, N+i);
+    add_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc);
+    //insert_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc, N+i);
   }
 
   // update internal counter after insertion
-  Nprtcls += number_of_incoming_particles-1;
+  //Nprtcls += number_of_incoming_particles-1;
 
 
 #ifdef GPU

--- a/core/pic/particle.c++
+++ b/core/pic/particle.c++
@@ -597,6 +597,9 @@ void ParticleContainer<D>::delete_particles(std::vector<int> to_be_deleted)
   nvtxRangePush(__PRETTY_FUNCTION__);
 #endif
 
+  assert(false);
+
+
   std::sort(to_be_deleted.begin(), to_be_deleted.end(), std::greater<int>() );
   
   float* locn[3];
@@ -1161,9 +1164,6 @@ void ParticleContainer<D>::unpack_incoming_particles()
   nvtxRangePush(__PRETTY_FUNCTION__);
 #endif
 
-  float locx, locy, locz, velx, vely, velz, wgts;
-  int ids, proc;
-
   // get real number of incoming particles
   int number_of_incoming_particles = incoming_particles[0].id; // number stored in id slot
   int number_of_incoming_extra_particles = incoming_extra_particles[0].id;
@@ -1189,24 +1189,24 @@ void ParticleContainer<D>::unpack_incoming_particles()
   //  << " seco:" << number_of_secondary_particles 
   //  << " N:"    << N << "\n"; 
 
-  reserve( N + number_of_incoming_particles - 2 );  //reserve for addition
+  reserve( N + number_of_incoming_particles - 2);  //reserve for addition
   //resize( N + number_of_incoming_particles - 2 );  // resize for insertion
 
   // skipping 1st info particle
   for(int i=1; i<number_of_primary_particles; i++){
     //std::cout << "inserting1 to slot" << N+i-1 << " out of " << N << "\n";
 
-    locx = incoming_particles[i].x;
-    locy = incoming_particles[i].y;
-    locz = incoming_particles[i].z;
+    float locx = incoming_particles[i].x;
+    float locy = incoming_particles[i].y;
+    float locz = incoming_particles[i].z;
 
-    velx = incoming_particles[i].ux;
-    vely = incoming_particles[i].uy;
-    velz = incoming_particles[i].uz;
-    wgts = incoming_particles[i].w;
+    float velx = incoming_particles[i].ux;
+    float vely = incoming_particles[i].uy;
+    float velz = incoming_particles[i].uz;
+    float wgts = incoming_particles[i].w;
 
-    ids  = incoming_particles[i].id;
-    proc = incoming_particles[i].proc;
+    int ids  = incoming_particles[i].id;
+    int proc = incoming_particles[i].proc;
 
     add_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc);
     //insert_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc, N+i-1 );
@@ -1216,17 +1216,17 @@ void ParticleContainer<D>::unpack_incoming_particles()
   for(int i=1; i<number_of_secondary_particles; i++){
     //std::cout << "inserting2 to slot" << N+i-1 << " out of " << N << "\n";
 
-    locx = incoming_extra_particles[i].x;
-    locy = incoming_extra_particles[i].y;
-    locz = incoming_extra_particles[i].z;
+    float locx = incoming_extra_particles[i].x;
+    float locy = incoming_extra_particles[i].y;
+    float locz = incoming_extra_particles[i].z;
 
-    velx = incoming_extra_particles[i].ux;
-    vely = incoming_extra_particles[i].uy;
-    velz = incoming_extra_particles[i].uz;
-    wgts = incoming_extra_particles[i].w;
+    float velx = incoming_extra_particles[i].ux;
+    float vely = incoming_extra_particles[i].uy;
+    float velz = incoming_extra_particles[i].uz;
+    float wgts = incoming_extra_particles[i].w;
 
-    ids  = incoming_extra_particles[i].id;
-    proc = incoming_extra_particles[i].proc;
+    int ids  = incoming_extra_particles[i].id;
+    int proc = incoming_extra_particles[i].proc;
       
     add_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc);
     //insert_identified_particle({locx,locy,locz}, {velx,vely,velz}, wgts, ids, proc, N+i-1);

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -45,12 +45,12 @@ struct Particle {
 
 
 // data struct for coupling tile send/recv directions together 
-struct to_other_tiles_struct{
-  int i;
-  int j;
-  int k;
-  size_t n;
-};
+//struct to_other_tiles_struct{
+//  int i;
+//  int j;
+//  int k;
+//  size_t n;
+//};
 
 /*! \brief Container of particles inside the tile
 *
@@ -137,8 +137,8 @@ class ParticleContainer{
   ManVec<float> Bpart;
 
   //! multimap of particles going to other tiles
-  using mapType = ManVec<to_other_tiles_struct>;
-  mapType to_other_tiles;
+  //using mapType = ManVec<to_other_tiles_struct>;
+  //mapType to_other_tiles;
 
   // particle charge 
   double q = 1.0; 
@@ -317,6 +317,29 @@ class ParticleContainer{
     //return indArr[idim];
     std::vector<int> ret;
     for(const auto& e: indArr[idim])
+      ret.push_back(e);
+    return ret;
+  }
+
+  //--------------------------------------------------
+  // info
+  DEVCALLABLE
+  inline int info( size_t iprtcl ) const
+  {
+    return infoArr[iprtcl];
+  }
+
+  DEVCALLABLE
+  inline int& info( size_t iprtcl )       
+  {
+    return infoArr[iprtcl];
+  }
+
+  inline std::vector<int> infos()
+  {
+    //return wgtArr;
+    std::vector<int> ret;
+    for(const auto& e: infoArr)
       ret.push_back(e);
     return ret;
   }

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -83,6 +83,8 @@ class ParticleContainer{
   int Nprtcls = 0;
   int cid = 0; // container identification id (minted with tile id)
 
+  int Nprtcls_cap = 0; //current capacity of the arrays
+
   // these arrays are required for QED interactions
   ManVec<float> wgtCumArr;              // cumulative weights; kept 0 if not needed
   ManVec<float> eneArr;                 // particle energies
@@ -360,6 +362,12 @@ class ParticleContainer{
       float prtcl_wgt, 
       int _id, int _proc);
 
+  // insert a particle to pre-reserved array; dangerous! 
+  virtual void insert_identified_particle (
+      std::vector<float> prtcl_loc,
+      std::vector<float> prtcl_vel,
+      float prtcl_wgt, 
+      int _id, int _proc, int ind);
 
   // --------------------------------------------------
   // particle boundary checks

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -45,12 +45,12 @@ struct Particle {
 
 
 // data struct for coupling tile send/recv directions together 
-//struct to_other_tiles_struct{
-//  int i;
-//  int j;
-//  int k;
-//  size_t n;
-//};
+struct to_other_tiles_struct{
+  int i;
+  int j;
+  int k;
+  size_t n;
+};
 
 /*! \brief Container of particles inside the tile
 *
@@ -137,8 +137,8 @@ class ParticleContainer{
   ManVec<float> Bpart;
 
   //! multimap of particles going to other tiles
-  //using mapType = ManVec<to_other_tiles_struct>;
-  //mapType to_other_tiles;
+  using mapType = ManVec<to_other_tiles_struct>;
+  mapType to_other_tiles;
 
   // particle charge 
   double q = 1.0; 

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -419,7 +419,7 @@ class ParticleContainer{
   void delete_transferred_particles();
 
   /// process through an index list and delete particles in it
-  void delete_particles(std::vector<int> to_be_deleted);
+  //void delete_particles(std::vector<int> to_be_deleted);
 
   /// transfer particles between blocks
   void transfer_and_wrap_particles(

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -18,7 +18,7 @@
 
 namespace pic {
 
-/// Particle data struct for communication; designe to be POD
+/// Particle data struct for communication; desiged to be POD
 // NOTE: ParticleContainer checks the validity of this struct in its
 //       own constructor.
 struct Particle {

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -127,7 +127,7 @@ class ParticleContainer{
   void unpack_incoming_particles();
 
   // size of MPI particle buffers
-  const int first_message_size = 4096; 
+  const int first_message_size = 16384; //4096; 
   // NOTE maximum prtcl size during first iteration is 2*first_msg; then resized
 
   //! particle specific electric field components

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -88,6 +88,10 @@ class ParticleContainer{
 
   int Nprtcls_cap = 0; //current capacity of the arrays
 
+  // mins and max limits for the exterior tile
+  std::array<double,D> mins; 
+  std::array<double,D> maxs;
+
   // these arrays are required for QED interactions
   ManVec<float> wgtCumArr;              // cumulative weights; kept 0 if not needed
   ManVec<float> eneArr;                 // particle energies

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -71,6 +71,7 @@ class ParticleContainer{
   /// unique key generator
   std::pair<int,int> keygen();
 
+
   protected:
 
   std::array<ManVec<float>, 3 > locArr; // x y z location
@@ -78,6 +79,7 @@ class ParticleContainer{
   std::array<ManVec<int>, 2 >   indArr; // cpu,id index
   ManVec<float> wgtArr;                 // weight
   ManVec<int>   infoArr;                // prtcl info (stores outflow information)
+
 
   public:
 
@@ -90,9 +92,13 @@ class ParticleContainer{
   ManVec<float> wgtCumArr;              // cumulative weights; kept 0 if not needed
   ManVec<float> eneArr;                 // particle energies
 
+  // size of MPI particle buffers
+  static const int first_message_size = 16384; //4096; 
+  // NOTE maximum prtcl size during first iteration is 2*first_msg; then resized
     
   /// packed outgoing particles
-  ManVec<Particle> outgoing_particles;
+  //ManVec<Particle> outgoing_particles;
+  std::array<Particle, first_message_size> outgoing_particles;
   ManVec<Particle> outgoing_extra_particles;
 
   /// pack all particles in the container
@@ -102,7 +108,8 @@ class ParticleContainer{
   void pack_outgoing_particles();
 
   /// packed incoming particles
-  ManVec<Particle> incoming_particles;
+  //ManVec<Particle> incoming_particles;
+  std::array<Particle, first_message_size> incoming_particles;
   ManVec<Particle> incoming_extra_particles;
 
 #ifdef GPU
@@ -126,9 +133,6 @@ class ParticleContainer{
   /// unpack incoming particles into internal vectors
   void unpack_incoming_particles();
 
-  // size of MPI particle buffers
-  const int first_message_size = 16384; //4096; 
-  // NOTE maximum prtcl size during first iteration is 2*first_msg; then resized
 
   //! particle specific electric field components
   ManVec<float> Epart;

--- a/core/pic/particle.h
+++ b/core/pic/particle.h
@@ -75,8 +75,9 @@ class ParticleContainer{
 
   std::array<ManVec<float>, 3 > locArr; // x y z location
   std::array<ManVec<float>, 3 > velArr; // vx vy vz velocities
-  std::array<ManVec<int>, 2 > indArr;     // cpu,id index
+  std::array<ManVec<int>, 2 >   indArr; // cpu,id index
   ManVec<float> wgtArr;                 // weight
+  ManVec<int>   infoArr;                // prtcl info (stores outflow information)
 
   public:
 
@@ -173,7 +174,7 @@ class ParticleContainer{
   DEVCALLABLE size_t size() const { 
 
 #ifdef DEBUG
-    bool ts[9] = {0,0,0,0,0,0,0,0,0};
+    bool ts[10] = {0,0,0,0,0,0,0,0,0,0};
 
     ts[0] = locArr[0].size() == locArr[1].size();
     ts[1] = locArr[0].size() == locArr[2].size();
@@ -183,7 +184,8 @@ class ParticleContainer{
     ts[5] = locArr[0].size() == indArr[0].size();
     ts[6] = locArr[0].size() == indArr[1].size();
     ts[7] = locArr[0].size() == wgtArr.size();
-    ts[8] = locArr[0].size() == static_cast<size_t>(Nprtcls);
+    ts[8] = locArr[0].size() == infoArr.size();
+    ts[9] = locArr[0].size() == static_cast<size_t>(Nprtcls);
 
     //bool ts2 = 0;
     //for(size_t i = 0; i<9; i++) ts2 += !ts[i];
@@ -196,7 +198,8 @@ class ParticleContainer{
         !ts[5] ||
         !ts[6] ||
         !ts[7] ||
-        !ts[8] ){
+        !ts[8] ||
+        !ts[9] ){
       std::cerr << "ERROR: particle number mismatch\n";
       std::cerr << locArr[0].size() << std::endl;
       std::cerr << locArr[1].size() << std::endl;
@@ -207,6 +210,7 @@ class ParticleContainer{
       std::cerr << indArr[0].size() << std::endl;
       std::cerr << indArr[1].size() << std::endl;
       std::cerr << wgtArr.size()    << std::endl;
+      std::cerr << infoArr.size()   << std::endl;
       std::cerr << Nprtcls          << std::endl;
       assert(false);
     }

--- a/core/pic/tile.c++
+++ b/core/pic/tile.c++
@@ -354,9 +354,7 @@ std::vector<mpi::request> Tile<D>::recv_particle_extra_data(
     auto& container = get_container(ispc);
     //container.incoming_extra_particles.clear();
       
-    //std::cout << "recv_prtcl: got " << 
-    //  container.incoming_particles[0].number_of_particles()
-    //  << " by mpi\n";
+    //std::cout << "recv_prtcl: got " << container.incoming_particles[0].id << " by mpi\n";
 
     // check if we need to expect extra message
     //extra_size = msginfo.size() - container.first_message_size;

--- a/core/pic/tile.c++
+++ b/core/pic/tile.c++
@@ -272,7 +272,12 @@ std::vector<mpi::request> Tile<D>::send_particle_extra_data(
           );
     }
 
-    //std::cout << this->communication.cid << " send " << container.outgoing_particles.size() << " + " << container.outgoing_extra_particles.size() << " particles\n";
+    std::cout << this->communication.cid 
+      << " send " << container.outgoing_particles.size() 
+      << " / " << container.outgoing_particles[0].id
+      << " + " << container.outgoing_extra_particles.size() 
+      << " / " << container.outgoing_extra_particles[0].id
+      << " particles\n";
   }
 
 #ifdef GPU
@@ -354,7 +359,8 @@ std::vector<mpi::request> Tile<D>::recv_particle_extra_data(
     auto& container = get_container(ispc);
     //container.incoming_extra_particles.clear();
       
-    //std::cout << "recv_prtcl: got " << container.incoming_particles[0].id << " by mpi\n";
+    std::cout << "recv_prtcl1: got " << container.incoming_particles[0].id << " by mpi\n";
+    std::cout << "recv_prtcl2: got " << container.incoming_extra_particles[0].id << " by mpi\n";
 
     // check if we need to expect extra message
     //extra_size = msginfo.size() - container.first_message_size;

--- a/core/pic/tile.c++
+++ b/core/pic/tile.c++
@@ -352,30 +352,17 @@ std::vector<mpi::request> Tile<D>::recv_particle_extra_data(
 
   std::vector<mpi::request> reqs;
 
-  // this assumes that wait for the first message is already called
-  // and passed.
+  // this assumes that wait for the first message is already called and passed.
 
   // normal particles
   for (int ispc=0; ispc<Nspecies(); ispc++) {
     auto& container = get_container(ispc);
-    //container.incoming_extra_particles.clear();
-      
+
     //std::cout << "recv_prtcl1: got " << container.incoming_particles[0].id << " by mpi\n";
-
-    // check if we need to expect extra message
-    //extra_size = msginfo.size() - container.first_message_size;
-
-    // NOTE number of particles stored in id slot
-    //int extra_size = container.incoming_particles[0].id - container.first_message_size;
-    //extra_size = extra_size <= 0 ? 1 : extra_size; // minimum of 1 info prtcl
-      
-    //std::cout << "recv_prtcl2: got " << container.incoming_extra_particles[0].id <<  " / " << np_extra << " by mpi\n";
-    //assert(np_extra == container.incoming_extra_particles[0].id );
 
     int first_message_size = container.first_message_size;
     int np_tot = container.incoming_particles[0].id;
     int np_extra = np_tot > first_message_size ? np_tot - first_message_size : 0;
-
 
     if(np_extra > 0) {
       container.incoming_extra_particles.resize(np_extra);
@@ -387,13 +374,9 @@ std::vector<mpi::request> Tile<D>::recv_particle_extra_data(
           );
     } else {
       container.incoming_extra_particles.clear();
-      //container.incoming_extra_particles.shrink_to_fit();
     }
 
     //std::cout << this->communication.cid << " recv " << container.incoming_particles.size() << " + " << container.incoming_extra_particles.size() << " particles\n";
-
-    //TODO: dynamic first_message_size here
-    //container.first_message_size = msginfo.size();
   }
 
 #ifdef GPU
@@ -447,10 +430,6 @@ void Tile<D>::shrink_to_fit_all_particles()
 {
   for(auto&& container : containers) {
 
-    // mpi main containers (should remain the same if not dynamical sizing)
-    //container.incoming_particles.resize(container.first_message_size);
-    //container.outgoing_particles.resize(container.first_message_size);
-
     // mpi extra message containers
     container.incoming_extra_particles.shrink_to_fit();
     container.outgoing_extra_particles.shrink_to_fit();
@@ -458,7 +437,6 @@ void Tile<D>::shrink_to_fit_all_particles()
     // internal main particle containers
     container.shrink_to_fit();
   }
-
 }
 
 

--- a/core/pic/tile.c++
+++ b/core/pic/tile.c++
@@ -368,13 +368,14 @@ std::vector<mpi::request> Tile<D>::recv_particle_extra_data(
     // NOTE number of particles stored in id slot
     //int extra_size = container.incoming_particles[0].id - container.first_message_size;
     //extra_size = extra_size <= 0 ? 1 : extra_size; // minimum of 1 info prtcl
+      
+    //std::cout << "recv_prtcl2: got " << container.incoming_extra_particles[0].id <<  " / " << np_extra << " by mpi\n";
+    //assert(np_extra == container.incoming_extra_particles[0].id );
 
     int first_message_size = container.first_message_size;
     int np_tot = container.incoming_particles[0].id;
-    int np_extra = np_tot-1 > first_message_size ? np_tot - first_message_size : 1;
+    int np_extra = np_tot > first_message_size ? np_tot - first_message_size : 0;
 
-    //std::cout << "recv_prtcl2: got " << container.incoming_extra_particles[0].id <<  " / " << np_extra << " by mpi\n";
-    //assert(np_extra == container.incoming_extra_particles[0].id );
 
     if(np_extra > 0) {
       container.incoming_extra_particles.resize(np_extra);

--- a/core/pic/tile.c++
+++ b/core/pic/tile.c++
@@ -361,6 +361,7 @@ std::vector<mpi::request> Tile<D>::recv_particle_extra_data(
 
     // NOTE number of particles stored in id slot
     extra_size = container.incoming_particles[0].id - container.first_message_size;
+    extra_size = extra_size <= 0 ? 1 : extra_size; // minimum of 1 info prtcl
 
     if(extra_size > 0) {
       container.incoming_extra_particles.resize(extra_size);
@@ -372,7 +373,7 @@ std::vector<mpi::request> Tile<D>::recv_particle_extra_data(
           );
     } else {
       container.incoming_extra_particles.clear();
-      container.incoming_extra_particles.shrink_to_fit();
+      //container.incoming_extra_particles.shrink_to_fit();
     }
 
     //std::cout << this->communication.cid << " recv " << container.incoming_particles.size() << " + " << container.incoming_extra_particles.size() << " particles\n";

--- a/core/pic/tile.c++
+++ b/core/pic/tile.c++
@@ -237,7 +237,7 @@ std::vector<mpi::request> Tile<D>::send_particle_data(
     reqs.emplace_back(
         comm.isend(dest, get_tag(tag, ispc), 
           container.outgoing_particles.data(), 
-          container.outgoing_particles.size())
+          container.first_message_size)
         );
   }
 

--- a/core/pic/tile.h
+++ b/core/pic/tile.h
@@ -57,6 +57,10 @@ public:
     // label container with tile cid; used for identifying containers when debugging
     block.cid = cid;
 
+    // label container with exterior tile limits
+    block.mins = mins;
+    block.maxs = maxs;
+
     // add 
     containers.push_back(block); 
   };

--- a/core/qed/pairing_all2all.h
+++ b/core/qed/pairing_all2all.h
@@ -221,7 +221,7 @@ public:
     {
       con.sort_in_rev_energy();
       //con.update_cumulative_arrays();
-      con.to_other_tiles.clear(); // empty tmp container; we store killed particles here
+      //con.to_other_tiles.clear(); // empty tmp container; we store killed particles here
     }
 
     //--------------------------------------------------
@@ -332,7 +332,7 @@ public:
                     } else { // else destroy previous and add new 
 
                       // destroy current
-                      con1.to_other_tiles.push_back( {1,1,1,n1} ); // NOTE: CPU version
+                      con1.info(n1) = -1; //to_other_tiles.push_back( {1,1,1,n1} ); // NOTE: CPU version
                       con1.wgt(n1) = 0.0f; // make zero wgt so its omitted from loop
 
                       // add new
@@ -355,7 +355,7 @@ public:
                     } else { // else destroy previous and add new 
 
                       // destroy current
-                      con2.to_other_tiles.push_back( {1,1,1,n2} ); // NOTE: CPU version
+                      con2.info(n2) = -1; //to_other_tiles.push_back( {1,1,1,n2} ); // NOTE: CPU version
                       con2.wgt(n2) = 0.0f; // make zero wgt so its omitted from loop
 
                       // add_particle
@@ -400,7 +400,7 @@ public:
     std::map<std::string, ConPtr> cons;
     for(auto&& con : tile.containers) cons.emplace(con.type, &con );
 
-    cons[t1]->to_other_tiles.clear(); // clear book keeping array
+    //cons[t1]->to_other_tiles.clear(); // clear book keeping array
 
     size_t N1 = cons[t1]->size(); // read particle number from here; 
 
@@ -419,7 +419,7 @@ public:
 
       zeta = rand();
       if( zeta < prob_kill) {
-        cons[t1]->to_other_tiles.push_back( {1,1,1,n1} ); // NOTE: CPU deletion version
+        cons[t1]->info(n1) = -1; //to_other_tiles.push_back( {1,1,1,n1} ); // NOTE: CPU deletion version
         cons[t1]->wgt(n1) = 0.0f; 
       } else {
         cons[t1]->wgt(n1) = w1*f_kill; // compensate lost particles by increasing w
@@ -673,7 +673,7 @@ public:
     std::string t1 = "ph";
     size_t Nx = cons[t1]->size(); // read particle number from here; 
                                   //
-    cons[t1]->to_other_tiles.clear(); // clear book keeping array
+    //cons[t1]->to_other_tiles.clear(); // clear book keeping array
 
     float w, x, f, sKN; //, P_esc;
     for(size_t n1=0; n1<Nx; n1++) {
@@ -732,7 +732,7 @@ public:
         // book keeping of escaped flux
         add_to_histogram(x, w);
 
-        cons[t1]->to_other_tiles.push_back( {1,1,1,n1} ); // NOTE: CPU deletion version
+        cons[t1]->info(n1) = -1; //to_other_tiles.push_back( {1,1,1,n1} ); // NOTE: CPU deletion version
         cons[t1]->wgt(n1) = 0.0f; 
       }
 

--- a/external/iter/dynArray.h
+++ b/external/iter/dynArray.h
@@ -137,6 +137,7 @@
         }
 
 
+        // v0
         inline void push_back(T val)
         {
             //
@@ -151,6 +152,44 @@
                 push_back(val);
             }
         }
+
+        //v1 and v2 with emplace_back as the lowest operation
+
+        //v1
+        //template <typename... Args>
+        //inline void emplace_back(Args&&... args) {
+        //  //if (size == capacity) grow();
+        //  if(count+1 > cap) {
+        //    realloc((cap+1)*overAllocFactor);
+        //  }
+        //  
+        //  return *new (start + size++) T(std::forward<Args>(args)...);
+        //}
+        //inline void push_back(const T & t) { return emplace_back(t); }
+        //inline void push_back(T && t) { return emplace_back(std::move(t)); }
+
+        //v2
+        //template<class... Args>
+        //inline void emplace_back(Args&&... args) {
+
+        //  if(count+1 > cap){
+        //    realloc((cap+1)*overAllocFactor);
+        //  }
+
+        //  ptr[count] = T(std::forward<Args>(args)...);
+        //  count++;
+        //  return;
+        //}
+
+        //inline void push_back(T&& val) {
+        //  emplace_back(std::move(val));
+        //}
+
+        //inline void push_back(const T& val) {
+        //  emplace_back(val);
+        //}
+
+
 
         inline void reserve(size_t newCap)
         {

--- a/projects/pic-shocks/1dsig3.ini
+++ b/projects/pic-shocks/1dsig3.ini
@@ -1,16 +1,16 @@
 [io]
 outdir: "auto"    # dir name; auto->make it based on conf params
 prefix: "shock_"  # prefix for the dir name
-postfix: "_v3"    # postfix for the dir name
+postfix: "_v7"    # postfix for the dir name
 
 
-interval: 200     # output frequency in units of simulation steps for analysis files
+interval: 2000    # output frequency in units of simulation steps for analysis files
 full_interval: -1 # output frequency to write full simulation snapshots
-restart:  20000   # frequency to write restart files (these overwrite previous files)
+restart:  2000000  # frequency to write restart files (these overwrite previous files)
 laprestart: -1    # restart switch (-1 no restart; 0 automatic; X lap to restart)
 
-stride: 1         # output reduce factor; NxMesh/stride must be int
-stride_mom: 1     # output reduce factor for moments; NxMesh/stride must be int
+stride: 32        # output reduce factor; NxMesh/stride must be int
+stride_mom: 32    # output reduce factor for moments; NxMesh/stride must be int
 
 # hi-res shock output parameters
 box_nx: 1200     # lenght of hi-res box region
@@ -21,7 +21,7 @@ mpi_task_mode: False # rank0 is kept empty if true; memory optimization
 
 #--------------------------------------------------
 [simulation]
-Nt: 30000       # maximum simulation laps to take
+Nt: 1500000      # maximum simulation laps to take
 cfl: 0.45        # time step in units of CFL
 npasses: 4       # number of current filter passes
 
@@ -53,16 +53,16 @@ gamma: 10.0  # upstream bulk flow speed
 
 # injector (right wall)
 use_injector: True  # flip switch for expanding box with moving right wall injector
-betainj:  0.99      # rightmost injector speed
-betarefl: 0.0       # leftmost chunking wall speed
+betainj:  0.95     # rightmost injector speed
+betarefl: 0.88      # leftmost chunking wall speed
 inj_startx: 20.0    # injector starting location (in skin depths)
-inj_interval:  100  # lap injector interval
+inj_interval:  1    # lap injector interval
 inj_damping_region: 20.0  # width of injector damping region in cells
 
 
 # reflector/chunker (left wall)
-refl_lag: 10000     # time step lag before reflector starts chunking
-refl_interval:10000 # lap chunking interval for reflector
+refl_lag: 20000     # time step lag before reflector starts chunking
+refl_interval:1000  # lap chunking interval for reflector
 wallgamma: 0.0      # x velocity of the left piston wall (value <1 are considered as beta)
 
 # use constant EM fields in pusher and only solve for fluctuating parts with field solver
@@ -78,10 +78,10 @@ n_test_prtcls: 10000  #number of test particles used
 
 #spatial grid parameters 
 [grid]
-Nx:     128  # tile numbers
+Nx:     512  # tile numbers
 Ny:     1
 Nz:     1
-NxMesh: 128  # internal tile grid
+NxMesh: 1024  # internal tile grid
 NyMesh: 1
 NzMesh: 1 
 
@@ -90,7 +90,7 @@ NzMesh: 1
 # twoD: True
 # threeD: False
 
-c_omp: 10 # nbr cells per skindepth
+c_omp: 25 # nbr cells per skindepth
 
 
 #individual velocity mesh parameters

--- a/projects/pic-shocks/3dsig3.ini
+++ b/projects/pic-shocks/3dsig3.ini
@@ -1,7 +1,7 @@
 [io]
 outdir: "auto"    # dir name; auto->make it based on conf params
 prefix: "shock_"  # prefix for the dir name
-postfix: "_v8"    # postfix for the dir name
+postfix: "_v7"    # postfix for the dir name
 
 
 interval: 1000    # output frequency in units of simulation steps for analysis files
@@ -27,7 +27,7 @@ npasses: 8       # number of current filter passes
 
 c_corr: 1.0      # EM field c correction
 
-mpi_track: 16    # catepillar cycle lenght
+mpi_track: 1    # catepillar cycle lenght
 
 #--------------------------------------------------
 [problem]
@@ -39,9 +39,9 @@ me: -1.0         # electron mass-to-charge
 mi: +1.0         # ion mass-to-charge
 
 #--------------------------------------------------
-bpar:  0.7071068 # B_x parallel component fraction
-bplan: 0.0       # B_y
-bperp: 0.7071068 # B_z (perpendicular) component fraction
+bpar:  0.0 # B_x parallel component fraction
+bplan: 0.0 # B_y
+bperp: 1.0 # B_z (perpendicular) component fraction
 
 #--------------------------------------------------
 # shock parameters
@@ -78,12 +78,12 @@ n_test_prtcls: 10000  #number of test particles used
 
 #spatial grid parameters 
 [grid]
-Nx:     1024 # 2048 #256  # tile numbers
-Ny:     2
-Nz:     1
-NxMesh: 60  # internal tile grid
-NyMesh: 60
-NzMesh: 1 
+Nx:     2048 #256  # tile numbers
+Ny:     4
+Nz:     4
+NxMesh: 30  # internal tile grid
+NyMesh: 30
+NzMesh: 30
 
 # forced dimensionality
 # oneD: False

--- a/projects/pic-shocks/injector.py
+++ b/projects/pic-shocks/injector.py
@@ -272,7 +272,7 @@ class MovingInjector:
             if conf.oneD:
                 i, j, k  = ind[0], 0, 0
             elif conf.twoD:
-                i,j,k = ind,0
+                i,j,k = ind[0],ind[1],0
             else:
                 i,j,k = ind
 

--- a/projects/pic-shocks/jobs/1dsig3.hile
+++ b/projects/pic-shocks/jobs/1dsig3.hile
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH -J 1ds3-x512
+#SBATCH -p cpu
+#SBATCH --output=%J.out
+#SBATCH --error=%J.err
+#SBATCH -t 10-00:00:00
+#SBATCH --nodes=1
+#SBATCH -n 32                 # total num of cores
+#SBATCH --ntasks-per-node=32  # 128 for amd epyc romes
+#SBATCH -c 1                  # cores per task
+#SBATCH --mem-per-cpu=30G     # max 8G
+ 
+#SBATCH --exclude=x3000c0s14b1n0,x3000c0s14b2n0,x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0,x3000c0s16b2n0,x3000c0s16b3n0
+
+# activate threading
+export OMP_NUM_THREADS=1
+export PYTHONDONTWRITEBYTECODE=true
+export HDF5_USE_FILE_LOCKING=FALSE
+
+# go to working directory
+cd $RUNKODIR/projects/pic-shocks/
+ 
+srun --mpi=cray_shasta python3 pic.py --conf 1dsig3.ini   # Cray
+#srun --mpi=pmix python3 pic.py --conf 1dsig3.ini   # gcc

--- a/projects/pic-shocks/jobs/1dsig3.turso
+++ b/projects/pic-shocks/jobs/1dsig3.turso
@@ -1,0 +1,27 @@
+#!/bin/bash
+#SBATCH -J 1ds3
+#SBATCH -M ukko
+#SBATCH -p short
+#SBATCH --output=%J.out
+#SBATCH --error=%J.err
+#SBATCH -t 0-05:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=16
+#SBATCH --constraint=amd
+#SBATCH --exclusive
+
+# INFO: ukko AMD nodes have 128 EPYC Rome cores
+
+# modules
+module use /home/jnattila/modules
+module load runko
+
+# activate threading
+export OMP_NUM_THREADS=1
+export PYTHONDONTWRITEBYTECODE=true
+export HDF5_USE_FILE_LOCKING=FALSE
+
+# go to working directory
+cd $RUNKODIR/projects/pic-shocks/
+
+mpirun -n 16 python pic.py --conf 2dsig3.ini

--- a/projects/pic-shocks/jobs/2dsig3.hile
+++ b/projects/pic-shocks/jobs/2dsig3.hile
@@ -8,7 +8,8 @@
 #SBATCH -t 20-00:00:00         # max run time
 #SBATCH --nodes=1              # nodes reserved
 #SBATCH --mem-per-cpu=7G       # max 7G
-
+#SBATCH --distribution=block:block
+#
 # SBATCH --exclude=x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0
 # SBATCH --nodelist=x3000c0s16b3n0,x3000c0s18b2n0,x3000c0s18b3n0,x3000c0s18b4n0,x3000c0s16b4n0,x3000c0s18b1n0
 
@@ -27,5 +28,5 @@ export FI_CXI_RX_MATCH_MODE=hybrid # in case hardware storate overflows, we use 
 # go to working directory
 cd $RUNKODIR/projects/pic-shocks/
  
-srun --mpi=cray_shasta python3 pic.py --conf 2dsig3-slab.ini   # Cray
+srun --mpi=cray_shasta --pmi=cray python3 pic.py --conf 2dsig3-slab.ini   # Cray
 #srun --mpi=pmix python3 pic.py --conf 3dsig3.ini  # GCC + OpenMPI

--- a/projects/pic-shocks/jobs/2dsig3.hile
+++ b/projects/pic-shocks/jobs/2dsig3.hile
@@ -6,30 +6,26 @@
 #SBATCH -c 1                   # cores per task
 #SBATCH --ntasks-per-node=128  # 128 for amd epyc romes
 #SBATCH -t 20-00:00:00         # max run time
-#SBATCH --nodes=2              # nodes reserved
+#SBATCH --nodes=1              # nodes reserved
 #SBATCH --mem-per-cpu=7G       # max 7G
 
-# SBATCH --exclude=x3000c0s14b1n0,x3000c0s14b2n0,x3000c0s14b3n0
- 
-#SBATCH --nodelist=x3000c0s16b3n0,x3000c0s18b2n0,x3000c0s18b3n0,x3000c0s18b4n0,x3000c0s16b4n0,x3000c0s18b1n0
+# SBATCH --exclude=x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0
+# SBATCH --nodelist=x3000c0s16b3n0,x3000c0s18b2n0,x3000c0s18b3n0,x3000c0s18b4n0,x3000c0s16b4n0,x3000c0s18b1n0
 
 # HILE-C node list
 # x3000c0s14b1n0,x3000c0s14b2n0,x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0,x3000c0s16b2n0,x3000c0s16b3n0,x3000c0s16b4n0,x3000c0s18b1n0,x3000c0s18b2n0,x3000c0s18b3n0,x3000c0s18b4n0
-
-# running jobs 
-# x3000c0s16b4n0 
-# x3000c0s18b1n0
 
 # activate threading
 export OMP_NUM_THREADS=1
 export PYTHONDONTWRITEBYTECODE=true
 export HDF5_USE_FILE_LOCKING=FALSE
 
-export FI_CXI_DEFAULT_TX_SIZE=4096 # increase max MPI msgs per rank
+export FI_CXI_DEFAULT_TX_SIZE=16384 # 4096 # increase max MPI msgs per rank
+# export FI_CXI_RDZV_THRESHOLD=16384 # same but for slingshot <2.1
+export FI_CXI_RX_MATCH_MODE=hybrid # in case hardware storate overflows, we use software mem
 
 # go to working directory
 cd $RUNKODIR/projects/pic-shocks/
  
-srun --mpi=cray_shasta python3 pic.py --conf 2dsig3.ini   # Cray
- 
+srun --mpi=cray_shasta python3 pic.py --conf 2dsig3-slab.ini   # Cray
 #srun --mpi=pmix python3 pic.py --conf 3dsig3.ini  # GCC + OpenMPI

--- a/projects/pic-shocks/jobs/2dsig3.hile
+++ b/projects/pic-shocks/jobs/2dsig3.hile
@@ -1,0 +1,35 @@
+#!/bin/bash
+#SBATCH -J 2ds3-x1024
+#SBATCH -p cpu
+#SBATCH --output=%J.out
+#SBATCH --error=%J.err
+#SBATCH -c 1                   # cores per task
+#SBATCH --ntasks-per-node=128  # 128 for amd epyc romes
+#SBATCH -t 20-00:00:00         # max run time
+#SBATCH --nodes=2              # nodes reserved
+#SBATCH --mem-per-cpu=7G       # max 7G
+
+# SBATCH --exclude=x3000c0s14b1n0,x3000c0s14b2n0,x3000c0s14b3n0
+ 
+#SBATCH --nodelist=x3000c0s16b3n0,x3000c0s18b2n0,x3000c0s18b3n0,x3000c0s18b4n0,x3000c0s16b4n0,x3000c0s18b1n0
+
+# HILE-C node list
+# x3000c0s14b1n0,x3000c0s14b2n0,x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0,x3000c0s16b2n0,x3000c0s16b3n0,x3000c0s16b4n0,x3000c0s18b1n0,x3000c0s18b2n0,x3000c0s18b3n0,x3000c0s18b4n0
+
+# running jobs 
+# x3000c0s16b4n0 
+# x3000c0s18b1n0
+
+# activate threading
+export OMP_NUM_THREADS=1
+export PYTHONDONTWRITEBYTECODE=true
+export HDF5_USE_FILE_LOCKING=FALSE
+
+export FI_CXI_DEFAULT_TX_SIZE=4096 # increase max MPI msgs per rank
+
+# go to working directory
+cd $RUNKODIR/projects/pic-shocks/
+ 
+srun --mpi=cray_shasta python3 pic.py --conf 2dsig3.ini   # Cray
+ 
+#srun --mpi=pmix python3 pic.py --conf 3dsig3.ini  # GCC + OpenMPI

--- a/projects/pic-shocks/jobs/3dsig3.hile
+++ b/projects/pic-shocks/jobs/3dsig3.hile
@@ -1,0 +1,32 @@
+#!/bin/bash
+#SBATCH -J 3ds3-x2048
+#SBATCH -p cpu
+#SBATCH --output=%J.out
+#SBATCH --error=%J.err
+#SBATCH -c 1                   # cores per task
+#SBATCH --ntasks-per-node=64   # 128 for amd epyc romes
+#SBATCH -t 20-00:00:00         # max run time
+#SBATCH --nodes=8              # nodes reserved
+#SBATCH --mem-per-cpu=14G      # max 7G/128 cores
+
+#SBATCH --exclude=x3000c0s14b2n0,x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0
+# SBATCH --nodelist=x3000c0s14b1n0,x3000c0s14b2n0,x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0,x3000c0s16b2n0,x3000c0s18b2n0,x3000c0s18b3n0,x3000c0s18b4n0
+
+# HILE-C node list
+# x3000c0s14b1n0,x3000c0s14b2n0,x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0,x3000c0s16b2n0,x3000c0s16b3n0,x3000c0s16b4n0,x3000c0s18b1n0,x3000c0s18b2n0,x3000c0s18b3n0,x3000c0s18b4n0
+
+# specific environment variable settings
+export OMP_NUM_THREADS=1
+export PYTHONDONTWRITEBYTECODE=true
+export HDF5_USE_FILE_LOCKING=FALSE
+export FI_CXI_DEFAULT_TX_SIZE=16384 # 4096 # increase max MPI msgs per rank
+# export FI_CXI_RDZV_THRESHOLD=16384 # same but for slingshot <2.1
+export FI_CXI_RX_MATCH_MODE=hybrid # in case hardware storate overflows, we use software mem
+
+
+# go to working directory
+cd $RUNKODIR/projects/pic-shocks/
+ 
+srun --mpi=cray_shasta python3 pic.py --conf 3dsig3.ini   # Cray
+
+#srun --mpi=pmix python3 pic.py --conf 3dsig3.ini  # GCC + OpenMPI

--- a/projects/pic-shocks/jobs/3dsig3.hile
+++ b/projects/pic-shocks/jobs/3dsig3.hile
@@ -6,8 +6,9 @@
 #SBATCH -c 1                   # cores per task
 #SBATCH --ntasks-per-node=128  # 128 for amd epyc romes
 #SBATCH -t 20-00:00:00         # max run time
-#SBATCH --nodes=4              # nodes reserved
+#SBATCH --nodes=8              # nodes reserved
 #SBATCH --mem-per-cpu=7G       # max 7G/128 cores
+#SBATCH --distribution=block:block
 
 # SBATCH --exclude=x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0
 # SBATCH --nodelist=
@@ -19,10 +20,17 @@
 export OMP_NUM_THREADS=1
 export PYTHONDONTWRITEBYTECODE=true
 export HDF5_USE_FILE_LOCKING=FALSE
+
+
+# Cray optimizations
+export MPICH_OFI_STARTUP_CONNECT=1  # create mpi rank connections in the beginning, not on the fly
 export FI_CXI_DEFAULT_TX_SIZE=16384 # 4096 # increase max MPI msgs per rank
 # export FI_CXI_RDZV_THRESHOLD=16384 # same but for slingshot <2.1
 export FI_CXI_RX_MATCH_MODE=hybrid # in case hardware storate overflows, we use software mem
 
+
+# export FI_OFI_RXM_SAR_LIMIT=524288 # mpi small/eager msg limit in bytes
+# export FI_OFI_RXM_BUFFER_SIZE=131072 # mpi msg buffer of 128KiB
 
 # go to working directory
 cd $RUNKODIR/projects/pic-shocks/

--- a/projects/pic-shocks/jobs/counters.hile
+++ b/projects/pic-shocks/jobs/counters.hile
@@ -1,31 +1,44 @@
 #!/bin/bash
-#SBATCH -J 3ds3-x2048
+#SBATCH -J 3ds3-cntrs
 #SBATCH -p cpu
 #SBATCH --output=%J.out
 #SBATCH --error=%J.err
 #SBATCH -c 1                   # cores per task
-#SBATCH --ntasks-per-node=128  # 128 for amd epyc romes
-#SBATCH -t 20-00:00:00         # max run time
+ 
+# 2D (small run)
+# SBATCH --ntasks-per-node=64   # 128 for amd epyc romes
+# SBATCH -t 1-00:00:00         # max run time
+# SBATCH --nodes=2              # nodes reserved
+# SBATCH --mem-per-cpu=7G       # max 7G
+
+# 3D (larger run)
+#SBATCH --ntasks-per-node=128   # 128 for amd epyc romes
+#SBATCH -t 1-00:00:00         # max run time
 #SBATCH --nodes=4              # nodes reserved
-#SBATCH --mem-per-cpu=7G       # max 7G/128 cores
+#SBATCH --mem-per-cpu=7G       # max 7G
+
 
 # SBATCH --exclude=x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0
-# SBATCH --nodelist=
+# SBATCH --nodelist=x3000c0s16b3n0,x3000c0s18b2n0,x3000c0s18b3n0,x3000c0s18b4n0,x3000c0s16b4n0,x3000c0s18b1n0
 
 # HILE-C node list
 # x3000c0s14b1n0,x3000c0s14b2n0,x3000c0s14b3n0,x3000c0s14b4n0,x3000c0s16b1n0,x3000c0s16b2n0,x3000c0s16b3n0,x3000c0s16b4n0,x3000c0s18b1n0,x3000c0s18b2n0,x3000c0s18b3n0,x3000c0s18b4n0
 
-# specific environment variable settings
+# activate threading
 export OMP_NUM_THREADS=1
 export PYTHONDONTWRITEBYTECODE=true
 export HDF5_USE_FILE_LOCKING=FALSE
+
 export FI_CXI_DEFAULT_TX_SIZE=16384 # 4096 # increase max MPI msgs per rank
 # export FI_CXI_RDZV_THRESHOLD=16384 # same but for slingshot <2.1
 export FI_CXI_RX_MATCH_MODE=hybrid # in case hardware storate overflows, we use software mem
 
-
 # go to working directory
 cd $RUNKODIR/projects/pic-shocks/
- 
-srun --mpi=cray_shasta python3 pic.py --conf 3dsig3.ini   # Cray
-#srun --mpi=pmix python3 pic.py --conf 3dsig3.ini  # GCC + OpenMPI
+
+
+# add mpi counter monitors
+export MPICH_OFI_CXI_COUNTER_REPORT=5
+export MPICH_OFI_CXI_COUNTER_REPORT_FILE=$RUNKODIR/projects/pic-shocks/jobs/3ds3-mpich-counters
+
+srun --mpi=cray_shasta python3 pic.py --conf 3dsig3-counters.ini

--- a/projects/pic-shocks/pic.py
+++ b/projects/pic-shocks/pic.py
@@ -205,28 +205,26 @@ if __name__ == "__main__":
         import pyrunko.emf.threeD as pyfld # fld c++ bindings
     # --------------------------------------------------
     # setup grid
-    grid = pycorgi.Grid(conf.Nx, conf.Ny, conf.Nz)
-    grid.set_grid_lims(conf.xmin, conf.xmax, conf.ymin, conf.ymax, conf.zmin, conf.zmax)
-    sch.grid = grid # remember to update scheduler
-
+    sch.grid = pycorgi.Grid(conf.Nx, conf.Ny, conf.Nz)
+    sch.grid.set_grid_lims(conf.xmin, conf.xmax, conf.ymin, conf.ymax, conf.zmin, conf.zmax)
 
     # compute initial mpi ranks using Hilbert's curve partitioning
     if conf.use_injector and conf.mpi_track > 1:
-        pytools.load_catepillar_track_mpi(grid, conf.mpi_track, conf) 
+        pytools.load_catepillar_track_mpi(sch.grid, conf.mpi_track, conf) 
     else:
-        #pytools.load_mpi_y_strides(grid, conf) #equal x stripes
+        #pytools.load_mpi_y_strides(sch.grid, conf) #equal x stripes
 
         # advanced Hilbert curve optimization (leave 4 first ranks empty)
-        #if grid.size() > 24: # big run
-        #    pytools.balance_mpi_3D_rootmem(grid, 4) 
+        #if sch.grid.size() > 24: # big run
+        #    pytools.balance_mpi_3D_rootmem(sch.grid, 4) 
         #else:
 
-        pytools.balance_mpi(grid, conf) #Hilbert curve optimization 
+        pytools.balance_mpi(sch.grid, conf) #Hilbert curve optimization 
 
 
     # load pic tiles into grid
-    #pytools.pic.load_tiles(grid, conf)
-    load_damping_tiles(grid, conf) # NOTE different from regular intialization
+    #pytools.pic.load_tiles(sch.grid, conf)
+    load_damping_tiles(sch.grid, conf) # NOTE different from regular intialization
 
     # --------------------------------------------------
     # simulation restart
@@ -245,31 +243,31 @@ if __name__ == "__main__":
 
         # injecting plasma particles
         if not(conf.use_injector):
-            prtcl_stat = pytools.pic.inject(grid, velocity_profile, density_profile, conf)
+            prtcl_stat = pytools.pic.inject(sch.grid, velocity_profile, density_profile, conf)
             if sch.is_example_worker: 
                 print("injected:")
                 print("     e- prtcls: {}".format(prtcl_stat[0]))
                 print("     e+ prtcls: {}".format(prtcl_stat[1]))
 
         # inserting em grid
-        insert_em_fields(grid, conf, do_initialization=True)
+        insert_em_fields(sch.grid, conf, do_initialization=True)
 
         # save a snapshot of the state to disk
-        pytools.save_mpi_grid_to_disk(conf.outdir, 0, grid, conf)
+        pytools.save_mpi_grid_to_disk(conf.outdir, 0, sch.grid, conf)
 
     else:
         if sch.is_master:
             print("restarting simulation from lap {}...".format(io_stat["lap"]))
 
         # insert damping reference values
-        insert_em_fields(grid, conf, do_initialization=False)
+        insert_em_fields(sch.grid, conf, do_initialization=False)
 
         # read restart files
-        pyfld.read_grids(grid, io_stat["read_lap"], io_stat["read_dir"])
-        pypic.read_particles(grid, io_stat["read_lap"], io_stat["read_dir"])
+        pyfld.read_grids(sch.grid, io_stat["read_lap"], io_stat["read_dir"])
+        pypic.read_particles(sch.grid, io_stat["read_lap"], io_stat["read_dir"])
 
         # set particle types
-        for tile in pytools.tiles_all(grid):
+        for tile in pytools.tiles_all(sch.grid):
             for ispcs in range(conf.Nspecies):
                 container = tile.get_container(ispcs)
                 container.type = conf.prtcl_types[ispcs] # name container
@@ -283,15 +281,15 @@ if __name__ == "__main__":
     if sch.is_master: print("load balancing grid..."); sys.stdout.flush()
 
     # update boundaries
-    grid.analyze_boundaries()
-    grid.send_tiles()
-    grid.recv_tiles()
+    sch.grid.analyze_boundaries()
+    sch.grid.send_tiles()
+    sch.grid.recv_tiles()
     MPI.COMM_WORLD.barrier()
 
     if sch.is_master: print("loading virtual tiles..."); sys.stdout.flush()
 
     # load virtual mpi halo tiles
-    pytools.pic.load_virtual_tiles(grid, conf)
+    pytools.pic.load_virtual_tiles(sch.grid, conf)
 
 
     # --------------------------------------------------
@@ -361,16 +359,16 @@ if __name__ == "__main__":
 
     # quick field snapshots
     #fld_writer = pyfld.MasterFieldsWriter(
-    #fld_writer = pyfld.FieldsWriter(
-    #    conf.outdir,
-    #    conf.Nx,
-    #    conf.NxMesh,
-    #    conf.Ny,
-    #    conf.NyMesh,
-    #    conf.Nz,
-    #    conf.NzMesh,
-    #    conf.stride,
-    #)
+    fld_writer = pyfld.FieldsWriter(
+        conf.outdir,
+        conf.Nx,
+        conf.NxMesh,
+        conf.Ny,
+        conf.NyMesh,
+        conf.Nz,
+        conf.NzMesh,
+        conf.stride,
+    )
 
 
     # tracked particles; only works with no injector (id's are messed up when coming out from injector)
@@ -379,7 +377,7 @@ if __name__ == "__main__":
     #for ispc in [0, 1, 2]: #electrons & positrons
     #for ispc in [0]: #electrons
     if False:
-        mpi_comm_size = grid.size() if not(conf.mpi_task_mode) else grid.size() - 1
+        mpi_comm_size = sch.grid.size() if not(conf.mpi_task_mode) else sch.grid.size() - 1
         n_local_tiles = int(conf.Nx*conf.Ny*conf.Nz/mpi_comm_size)
         #print("average n_local_tiles:", n_local_tiles, " / ", mpi_comm_size)
 
@@ -387,7 +385,7 @@ if __name__ == "__main__":
                 conf.outdir,
                 conf.Nx, conf.NxMesh, conf.Ny, conf.NyMesh, conf.Nz, conf.NzMesh,
                 conf.ppc,
-                n_local_tiles, #len(grid.get_local_tiles()),
+                n_local_tiles, #len(sch.grid.get_local_tiles()),
                 conf.n_test_prtcls,)
         prtcl_writer.ispc = ispc
         prtcl_writers.append(prtcl_writer)
@@ -395,16 +393,15 @@ if __name__ == "__main__":
 
     # momens of particle distribution
     #mom_writer = pypic.MasterPicMomentsWriter(
-    #mom_writer = pypic.PicMomentsWriter(
-    #    conf.outdir,
-    #    conf.Nx,
-    #    conf.NxMesh,
-    #    conf.Ny,
-    #    conf.NyMesh,
-    #    conf.Nz,
-    #    conf.NzMesh,
-    #    conf.stride_mom,
-    #)
+    mom_writer = pypic.PicMomentsWriter(
+        conf.outdir,
+        conf.Nx,
+        conf.NxMesh,
+        conf.Ny,
+        conf.NyMesh,
+        conf.Nz,
+        conf.NzMesh,
+        conf.stride_mom,)
 
     # 3D box peripherals
     if conf.threeD:
@@ -465,7 +462,7 @@ if __name__ == "__main__":
                 print("injecting prtcls with moving injector")
                 sys.stdout.flush()
 
-            prtcl_stat = sch.rwall.inject(grid, lap, velocity_profile, density_profile, conf)
+            prtcl_stat = sch.rwall.inject(sch.grid, lap, velocity_profile, density_profile, conf)
             if sch.is_master:
                 print('injected e^-:', prtcl_stat[0])
                 print('injected e^+:', prtcl_stat[1])
@@ -484,7 +481,7 @@ if __name__ == "__main__":
         sch.rwall.step(0)
 
         for plap in range(0, lap):
-            do_slide = slider.slide(plap, grid, conf)
+            do_slide = slider.slide(plap, sch.grid, conf)
 
             if do_slide: sch.lwall.walloc = slider.xmin  # set reflecting box to end of the box
 
@@ -520,7 +517,7 @@ if __name__ == "__main__":
         # --------------------------------------------------
         # sliding box 
         t1 = sch.timer.start_comp("sliding_box")
-        do_slide = slider.slide(lap, grid, conf)
+        do_slide = slider.slide(lap, sch.grid, conf)
         if do_slide:
             sch.lwall.walloc = slider.xmin  # set reflecting box to the end of the box
         sch.timer.stop_comp(t1)
@@ -529,19 +526,19 @@ if __name__ == "__main__":
 
         # moving right injector
         t1 = sch.timer.start_comp("rwall_bc")
-        sch.rwall.damp_em_fields(grid, lap, conf)
+        sch.rwall.damp_em_fields(sch.grid, lap, conf)
         sch.timer.stop_comp(t1)
 
         if conf.use_injector:
             t1 = sch.timer.start_comp("rwall")
-            prtcl_stat = sch.rwall.inject(grid, lap, velocity_profile, density_profile, conf)
+            prtcl_stat = sch.rwall.inject(sch.grid, lap, velocity_profile, density_profile, conf)
             sch.timer.stop_comp(t1)
 
         # --------------------------------------------------
         # comm E and B
         sch.operate( dict(name='mpi_b0', solver='mpi', method='b', ) )
         sch.operate( dict(name='mpi_e0', solver='mpi', method='e', ) )
-        sch.operate( dict(name='upd_bc', solver='tile',method='update_boundaries', args=[grid,[1,2] ], nhood='local', ) )
+        sch.operate( dict(name='upd_bc', solver='tile',method='update_boundaries', args=[sch.grid,[1,2] ], nhood='local', ) )
 
         # --------------------------------------------------
         # push B half
@@ -550,7 +547,7 @@ if __name__ == "__main__":
 
         # comm B
         sch.operate( dict(name='mpi_b1',  solver='mpi', method='b',                 ) )
-        sch.operate( dict(name='upd_bc ', solver='tile',method='update_boundaries',args=[grid, [2,] ], nhood='local',) )
+        sch.operate( dict(name='upd_bc ', solver='tile',method='update_boundaries',args=[sch.grid, [2,] ], nhood='local',) )
 
         # --------------------------------------------------
         # move particles (only locals tiles)
@@ -575,7 +572,7 @@ if __name__ == "__main__":
 
         # comm B
         sch.operate( dict(name='mpi_b2', solver='mpi', method='b',                 ) )
-        sch.operate( dict(name='upd_bc', solver='tile',method='update_boundaries', args=[grid, [2,] ], nhood='local',) )
+        sch.operate( dict(name='upd_bc', solver='tile',method='update_boundaries', args=[sch.grid, [2,] ], nhood='local',) )
 
 
         # --------------------------------------------------
@@ -595,7 +592,7 @@ if __name__ == "__main__":
 
         sch.operate( dict(name='unpack_vir_prtcls',     solver='tile',  method='unpack_incoming_particles',    nhood='virtual', ) )
         sch.operate( dict(name='check_outg_vir_prtcls', solver='tile',  method='check_outgoing_particles',     nhood='virtual', ) )
-        sch.operate( dict(name='get_inc_prtcls',        solver='tile',  method='get_incoming_particles',       nhood='local', args=[grid,]) )
+        sch.operate( dict(name='get_inc_prtcls',        solver='tile',  method='get_incoming_particles',       nhood='local', args=[sch.grid,]) )
 
         sch.operate( dict(name='del_trnsfrd_prtcls',    solver='tile',  method='delete_transferred_particles', nhood='local', ) )
         sch.operate( dict(name='del_vir_prtcls',        solver='tile',  method='delete_all_particles',         nhood='virtual', ) )
@@ -606,7 +603,7 @@ if __name__ == "__main__":
         sch.operate( dict(name='comp_curr',     solver='currint', method='solve',             nhood='local', ) )
         sch.operate( dict(name='clear_vir_cur', solver='tile',    method='clear_current',     nhood='virtual', ) )
         sch.operate( dict(name='mpi_cur',       solver='mpi',     method='j',                 nhood='all', ) )
-        sch.operate( dict(name='cur_exchange',  solver='tile',    method='exchange_currents', nhood='local', args=[grid,], ) )
+        sch.operate( dict(name='cur_exchange',  solver='tile',    method='exchange_currents', nhood='local', args=[sch.grid,], ) )
 
         # --------------------------------------------------
         # filter
@@ -615,7 +612,7 @@ if __name__ == "__main__":
             # flt uses halo=2 padding so only every 3rd (0,1,2) pass needs update
             if fj % 2 == 0:
                 sch.operate( dict(name='mpi_cur_flt', solver='mpi', method='j', ) )
-                sch.operate( dict(name='upd_bc',      solver='tile',method='update_boundaries',args=[grid, [0,] ], nhood='local', ) )
+                sch.operate( dict(name='upd_bc',      solver='tile',method='update_boundaries',args=[sch.grid, [0,] ], nhood='local', ) )
 
                 #TODO is wall_bc needed here?
 
@@ -626,7 +623,7 @@ if __name__ == "__main__":
         # --------------------------------------------------
         # add antenna contribution for exciting waves
         #sch.antenna.update_rnd_phases()
-        #antenna.get_brms(grid) # debug tracking
+        #antenna.get_brms(sch.grid) # debug tracking
         #sch.operate( dict(name='add_antenna', solver='antenna', method='add_ext_cur', nhood='local', ) )
 
         # --------------------------------------------------
@@ -651,7 +648,7 @@ if __name__ == "__main__":
             # io/analyze (independent)
             sch.timer.start("io")
             # shrink particle arrays
-            for tile in pytools.tiles_all(grid):
+            for tile in pytools.tiles_all(sch.grid):
                 tile.shrink_to_fit_all_particles()
 
             # barrier for quick writers
@@ -659,19 +656,19 @@ if __name__ == "__main__":
 
             # shallow IO
             # NOTE: do moms before other IOs to keep rho field up-to-date
-            #mom_writer.write(grid, lap)  # pic distribution moments; 
-            #fld_writer.write(grid, lap)  # quick field snapshots
+            mom_writer.write(sch.grid, lap)  # pic distribution moments; 
+            fld_writer.write(sch.grid, lap)  # quick field snapshots
 
             for pw in prtcl_writers:
-                pw.write(grid, lap)  # particle tracking
+                pw.write(sch.grid, lap)  # particle tracking
             
-            #pytools.save_mpi_grid_to_disk(conf.outdir, lap, grid, conf) # MPI grid
+            #pytools.save_mpi_grid_to_disk(conf.outdir, lap, sch.grid, conf) # MPI grid
 
             #box peripheries 
             if conf.threeD:
-                slice_xy_writer.write(grid, lap)
-                slice_xz_writer.write(grid, lap)
-                slice_yz_writer.write(grid, lap)
+                slice_xy_writer.write(sch.grid, lap)
+                slice_xz_writer.write(sch.grid, lap)
+                slice_yz_writer.write(sch.grid, lap)
 
 
             #--------------------------------------------------
@@ -682,13 +679,13 @@ if __name__ == "__main__":
             shock_toolset.wloc0 = slider.xmin #downstream chunking sets left box limit
             shock_toolset.wloc1 = sch.rwall.wloc1 #upstream injector sets right box limit
 
-            shock_toolset.get_density_profile(grid, lap, conf)
-            shock_toolset.find_shock_front(grid, lap, conf, xmin=slider.xmin)
+            shock_toolset.get_density_profile(sch.grid, lap, conf)
+            shock_toolset.find_shock_front(sch.grid, lap, conf, xmin=slider.xmin)
 
-            shock_toolset.read_fields(grid, lap, conf)
-            shock_toolset.read_prtcls(grid, lap, conf)
+            shock_toolset.read_fields(sch.grid, lap, conf)
+            shock_toolset.read_prtcls(sch.grid, lap, conf)
 
-            shock_toolset.save(grid, lap, conf)
+            shock_toolset.save(sch.grid, lap, conf)
 
 
             #--------------------------------------------------
@@ -718,8 +715,8 @@ if __name__ == "__main__":
             #--------------------------------------------------
             # deep IO
             if conf.full_interval > 0 and (lap % conf.full_interval == 0) and (lap > 0):
-                pyfld.write_grids(grid, lap, conf.outdir + "/full_output/")
-                pypic.write_particles(grid, lap, conf.outdir + "/full_output/")
+                pyfld.write_grids(sch.grid, lap, conf.outdir + "/full_output/")
+                pypic.write_particles(sch.grid, lap, conf.outdir + "/full_output/")
 
 
             # restart IO (overwrites)
@@ -729,18 +726,18 @@ if __name__ == "__main__":
                 io_stat["deep_io_switch"] = 1 if io_stat["deep_io_switch"] == 0 else 0
 
                 pyfld.write_grids(
-                    grid, io_stat["deep_io_switch"] + io_stat['restart_num'],
+                    sch.grid, io_stat["deep_io_switch"] + io_stat['restart_num'],
                     conf.outdir + "/restart/"
                 )
 
                 pypic.write_particles(
-                    grid, io_stat["deep_io_switch"] + io_stat['restart_num'],
+                    sch.grid, io_stat["deep_io_switch"] + io_stat['restart_num'],
                     conf.outdir + "/restart/"
                 )
 
                 # if successful adjust info file
                 MPI.COMM_WORLD.barrier()  # sync everybody in case of failure before write
-                if grid.rank() == 0:
+                if sch.grid.rank() == 0:
                     with open(conf.outdir + "/restart/laps.txt", "a") as lapfile:
                         lapfile.write("{},{}\n".format(
                             lap, 

--- a/projects/pic-shocks/plot_dens.py
+++ b/projects/pic-shocks/plot_dens.py
@@ -381,7 +381,7 @@ if __name__ == "__main__":
     # if lap is defined, only plot that one individual round
     
     offs = 0
-    for lap in range(0, conf.Nt, 5*conf.interval):
+    for lap in range(0, conf.Nt, conf.interval):
         info = quick_build_info(fdir, lap)
         info['skindepth'] = conf.c_omp #/conf.stride
         print(info['shock_file'])

--- a/projects/pic-shocks/plot_jump_conds.py
+++ b/projects/pic-shocks/plot_jump_conds.py
@@ -888,9 +888,9 @@ if __name__ == "__main__":
     axs[1].minorticks_on()
     axs[2].minorticks_on()
 
-    axs[0].set_xlim((0,2000))
-    axs[1].set_xlim((0,2000))
-    axs[2].set_xlim((0,2000))
+    axs[0].set_xlim((0,15000))
+    axs[1].set_xlim((0,15000))
+    axs[2].set_xlim((0,15000))
 
     if True:
         #axs[1].set_ylim((0.2,1.0))

--- a/projects/pic-shocks/plot_jump_conds.py
+++ b/projects/pic-shocks/plot_jump_conds.py
@@ -888,9 +888,9 @@ if __name__ == "__main__":
     axs[1].minorticks_on()
     axs[2].minorticks_on()
 
-    axs[0].set_xlim((0,15000))
-    axs[1].set_xlim((0,15000))
-    axs[2].set_xlim((0,15000))
+    axs[0].set_xlim((0,1500))
+    axs[1].set_xlim((0,1500))
+    axs[2].set_xlim((0,1500))
 
     if True:
         #axs[1].set_ylim((0.2,1.0))

--- a/projects/pic-shocks/plot_upstream_ene.py
+++ b/projects/pic-shocks/plot_upstream_ene.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     #--------------------------------------------------
     # set up plot
     tmin = 0.0
-    tmax = 5e3
+    tmax = 1.5e4
 
     ax.set_yscale('log')
     #ax.set_xscale('log')

--- a/projects/pic-shocks/plot_upstream_ene.py
+++ b/projects/pic-shocks/plot_upstream_ene.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     #--------------------------------------------------
     # set up plot
     tmin = 0.0
-    tmax = 1.5e4
+    tmax = 1.5e3
 
     ax.set_yscale('log')
     #ax.set_xscale('log')

--- a/projects/pic-shocks/scripts.sh
+++ b/projects/pic-shocks/scripts.sh
@@ -1,18 +1,25 @@
-#!/bin/zsh
+#!/usr/bin/env bash
  
-# ! /usr/bin/env bash
+##!/bin/zsh
+ 
 
 declare -a conf_arr=(
-"2dsig3.ini"
+#"1dsig3.ini"
+#"shock_x256m128_p32np4c10_s3d1e-4_v5/1dsig3.ini"
+#"shock_x512m1024_p32np4c25_s3d1e-4_v6/1dsig3.ini"
+#"shock_x512m1024_p32np4c25_s3d1e-4_v7/1dsig3.ini"
+#"shock_x1024m60_p2np8c25_s3d1e-4_v6/2dsig3.ini"
+"shock_x1024m60_p2np8c25_s3d1e-4_v8/2dsig3.ini"
 )
 
 
 # one-time scripts that read all the time slices in one go
 declare -a single_scripts_arr=(
-#"plot_dens.py"
+"plot_dens.py"
+"plot_upstream_ene.py"    
+"plot_jump_conds.py"    
 #"plot_pspec.py"
 ##"plot_ene.py"    
-##"plot_upstream_ene.py"    
 )
 
 
@@ -44,7 +51,7 @@ done
 #-------------------------------------------------- 
 # multilap scripts
 
-for lap in {0..10000..100}
+for lap in {0..200000..1000}
 do
     echo "lap is $lap"
     for c in "${conf_arr[@]}"

--- a/projects/pic-shocks/shock_toolset.py
+++ b/projects/pic-shocks/shock_toolset.py
@@ -159,22 +159,22 @@ class ShockToolset:
             norm = n0 #*qe
 
             #v1: shock front tracking
-            #ind = where_last( self.density/norm > conf.shock_density_jump_thr)
+            ind = where_last( self.density/norm > conf.shock_density_jump_thr)
 
             #v2 shock front tracking where we test also that values left of the index have n_d/n_u > thr
-            nu_nd = self.density/norm 
-            while True:
-                ind = where_last( nu_nd > conf.shock_density_jump_thr )
-                mean_dens_behind = np.mean(nu_nd[ind-3*conf.c_omp:ind]) # mean density value behind found location
+            #nu_nd = self.density/norm 
+            #while True:
+            #    ind = where_last( nu_nd > conf.shock_density_jump_thr )
+            #    mean_dens_behind = np.mean(nu_nd[ind-3*conf.c_omp:ind]) # mean density value behind found location
 
-                #print( 'ind at', ind, 'nu/nd:', nu_nd[ind], 'mean val behind:', mean_dens_behind)
+            #    #print( 'ind at', ind, 'nu/nd:', nu_nd[ind], 'mean val behind:', mean_dens_behind)
 
-                if mean_dens_behind > conf.shock_density_jump_thr:
-                    break
-                elif ind == 0:
-                    break # unphysical situation
-                else:
-                    nu_nd = nu_nd[:ind] # cut point out and analyze the next
+            #    if mean_dens_behind > conf.shock_density_jump_thr:
+            #        break
+            #    elif ind == 0:
+            #        break # unphysical situation
+            #    else:
+            #        nu_nd = nu_nd[:ind] # cut point out and analyze the next
 
             # try to predic location roughly if the above test does not work
             if ind == 0:

--- a/projects/pic-turbulence/plot3d.py
+++ b/projects/pic-turbulence/plot3d.py
@@ -260,7 +260,7 @@ if __name__ == "__main__":
         
 
     # read just periphery or full box
-    do_periphery = False
+    do_periphery = True
     if not(do_periphery):
         def read_h5(outdir, fname, var, lap):
             return read_full_box(outdir, fname, var, lap)

--- a/pytools/load_grid.py
+++ b/pytools/load_grid.py
@@ -8,7 +8,7 @@ import pyrunko
 import scipy
 
 
-def balance_mpi(n, conf, comm_size=None):
+def balance_mpi(n, conf, comm_size=None, do_print=True):
 
     # test if conf has task mode defined; do not crash if it doesnt
     try: 
@@ -17,11 +17,11 @@ def balance_mpi(n, conf, comm_size=None):
         mpi_task_mode = False
 
     if conf.oneD:
-        return balance_mpi_1D(n, comm_size=comm_size)
+        return balance_mpi_1D(n, comm_size=comm_size, do_print=do_print)
     if conf.twoD:
-        return balance_mpi_2D(n, comm_size=comm_size)
+        return balance_mpi_2D(n, comm_size=comm_size, do_print=do_print)
     elif conf.threeD:
-        return balance_mpi_3D(n, comm_size=comm_size, mpi_task_mode=conf.mpi_task_mode)
+        return balance_mpi_3D(n, comm_size=comm_size, do_print=do_print, mpi_task_mode=conf.mpi_task_mode)
 
 
 
@@ -90,7 +90,7 @@ def balance_mpi_2D(n, comm_size=None):
 
 
 # load nodes using 3D Hilbert curve
-def balance_mpi_3D(n, comm_size=None, mpi_task_mode=False):
+def balance_mpi_3D(n, comm_size=None, mpi_task_mode=False, do_print=True):
 
     if n.rank() == 0:  # only master initializes; then sends
         if comm_size == None:
@@ -150,7 +150,8 @@ def balance_mpi_3D(n, comm_size=None, mpi_task_mode=False):
             except:
                 tiles_owned[int(nt)] = 1
 
-        print('lba : tiles owned per rank', tiles_owned, " (#tiles, #ranks)")
+        if do_print:
+            print('lba : tiles owned per rank', tiles_owned, " (#tiles, #ranks)")
         
 
         # print("grid:")
@@ -170,13 +171,14 @@ def balance_mpi_3D(n, comm_size=None, mpi_task_mode=False):
 # load nodes using 3D Hilbert curve
 # Leaves i_drop_rank first ranks to be empty. In addition, prints analysis of the grid state.
 # Can be used to balance the memory impact of the first node that has rank0 (which can have large arrays due to IO).
-def balance_mpi_3D_rootmem(n, i_drop_rank, comm_size=None):
+def balance_mpi_3D_rootmem(n, i_drop_rank, comm_size=None, do_print=True):
 
     if n.rank() == 0:  # only master initializes; then sends
         if comm_size == None:
             comm_size = n.size()
 
-        print("lba: loadbalancing grid with ", i_drop_rank, " empty ranks...")
+        if do_print:
+            print("lba: loadbalancing grid with ", i_drop_rank, " empty ranks...")
 
         #for i_drop_rank in range(1, mpi_task_mode+1):
         if True:
@@ -276,13 +278,14 @@ def balance_mpi_3D_rootmem(n, i_drop_rank, comm_size=None):
             #print('tiles_owned', i_drop_rank, tiles_owned, tot_nbors/(nx*ny*nz))
 
             #print('analysis: {:3d} mean(nbors): {:5.3f} mean(nbor/tiles): {5.3f}'.format(
-            print('lba: analysis: {:3d} mean(nbors): {:6.3f} min(nbors) {:6.3f} max(nbors) {:6.3f} mode(nbors) {:6.3f} mean(nbor/tile) {:6.3f}'.format(
-                i_drop_rank,
-                np.mean(nbors_per_rank),
-                np.min(nbors_per_rank),
-                np.max(nbors_per_rank),
-                np.median(nbors_per_rank),
-                np.mean(nbors_per_rank[1:]/tiles_per_rank[1:]),
+            if do_print:
+                print('lba: analysis: {:3d} mean(nbors): {:6.3f} min(nbors) {:6.3f} max(nbors) {:6.3f} mode(nbors) {:6.3f} mean(nbor/tile) {:6.3f}'.format(
+                    i_drop_rank,
+                    np.mean(nbors_per_rank),
+                    np.min(nbors_per_rank),
+                    np.max(nbors_per_rank),
+                    np.median(nbors_per_rank),
+                    np.mean(nbors_per_rank[1:]/tiles_per_rank[1:]),
                                            ))
 
         # print("grid:")
@@ -306,7 +309,9 @@ def load_catepillar_track_mpi(
         n, 
         nx_track_len,
         conf,
-        comm_size=None):
+        comm_size=None,
+        do_print=True
+        ):
 
 
     #if True:  # only master initializes; then sends
@@ -360,8 +365,9 @@ def load_catepillar_track_mpi(
                     grid[i, j, k] = val
                     val += 1.0
 
-        print('lba: grid')
-        print(grid[:,:,0])
+        if do_print:
+            print('lba: grid')
+            print(grid[:,:,0])
 
         hmin, hmax = np.min(grid), np.max(grid)
 
@@ -389,7 +395,9 @@ def load_catepillar_track_mpi(
                 tiles_owned[int(nt)] += 1
             except:
                 tiles_owned[int(nt)] = 1
-        print('lba : tiles owned per rank', tiles_owned, " (#tiles, #ranks)")
+
+        if do_print:
+            print('lba : tiles owned per rank', tiles_owned, " (#tiles, #ranks)")
 
         for i in range(nxt):
             for j in range(ny):

--- a/pytools/load_grid.py
+++ b/pytools/load_grid.py
@@ -146,9 +146,9 @@ def balance_mpi_3D(n, comm_size=None, mpi_task_mode=False):
         tiles_owned = {}
         for (rank, nt) in zip(ii, y[ii]):
             try:
-                tiles_owned[nt] += 1
+                tiles_owned[int(nt)] += 1
             except:
-                tiles_owned[nt] = 1
+                tiles_owned[int(nt)] = 1
 
         print('lba : tiles owned per rank', tiles_owned, " (#tiles, #ranks)")
         
@@ -229,9 +229,9 @@ def balance_mpi_3D_rootmem(n, i_drop_rank, comm_size=None):
             tiles_owned = {}
             for (rank, nt) in zip(ii, y[ii]):
                 try:
-                    tiles_owned[nt] += 1
+                    tiles_owned[int(nt)] += 1
                 except:
-                    tiles_owned[nt] = 1
+                    tiles_owned[int(nt)] = 1
 
             tile_nbors = {}
 
@@ -364,9 +364,15 @@ def load_catepillar_track_mpi(
         # check that nodes get about same work load
         y = np.bincount(igrid.flatten())
         ii = np.nonzero(y)[0]
+        grid_tile_list = list(zip(ii,y[ii]))
 
-        #print('rank load statistics')
-        #print(list(zip(ii,y[ii])))
+        tiles_owned = {}
+        for (rank, nt) in zip(ii, y[ii]):
+            try:
+                tiles_owned[nt] += 1
+            except:
+                tiles_owned[nt] = 1
+        print('lba : tiles owned per rank', tiles_owned, " (#tiles, #ranks)")
 
         for i in range(nxt):
             for j in range(ny):

--- a/pytools/load_grid.py
+++ b/pytools/load_grid.py
@@ -348,6 +348,9 @@ def load_catepillar_track_mpi(
                     elif conf.threeD:
                         grid[i, j, k] = hgen.hindex(i, j, k)
 
+        print('lba: grid')
+        print(grid[:,:,0])
+
         # print(grid)
         hmin, hmax = np.min(grid), np.max(grid)
 
@@ -360,6 +363,9 @@ def load_catepillar_track_mpi(
                 for k in range(nz):
                     ic = i % nx
                     igrid[i, j, k] = np.floor(comm_size * grid[ic, j, k] / (hmax + 1))
+
+        print('lba: full grid')
+        print(igrid[:,:,0])
 
         # check that nodes get about same work load
         y = np.bincount(igrid.flatten())

--- a/pytools/load_grid.py
+++ b/pytools/load_grid.py
@@ -319,39 +319,50 @@ def load_catepillar_track_mpi(
         ny = n.get_Ny()
         nz = n.get_Nz()
 
-        m0 = np.log2(nx)
-        m1 = np.log2(ny)
-        m2 = np.log2(nz)
-
-        if not (m0.is_integer()):
-            raise ValueError("Nx is not power of 2 (i.e. 2^m)")
-
-        if not (m1.is_integer()):
-            raise ValueError("Ny is not power of 2 (i.e. 2^m)")
-        
-        if conf.threeD and not( m2.is_integer() ):
-            raise ValueError("Nz is not power of 2 (i.e. 2^m)")
-
-        # print('Generating hilbert with 2^{} {}'.format(m0,m1))
-        if conf.oneD or conf.twoD:
-            hgen = pyrunko.tools.twoD.HilbertGen(int(m0), int(m1))
-        elif conf.threeD:
-            hgen = pyrunko.tools.threeD.HilbertGen(int(m0), int(m1), int(m2) )
-
         grid = np.zeros((nx, ny, nz))  # , int)
 
+        #-------------------------------------------------- 
+        # Hilbert curve
+
+        #m0 = np.log2(nx)
+        #m1 = np.log2(ny)
+        #m2 = np.log2(nz)
+
+        #if not (m0.is_integer()):
+        #    raise ValueError("Nx is not power of 2 (i.e. 2^m)")
+
+        #if not (m1.is_integer()):
+        #    raise ValueError("Ny is not power of 2 (i.e. 2^m)")
+        #
+        #if conf.threeD and not( m2.is_integer() ):
+        #    raise ValueError("Nz is not power of 2 (i.e. 2^m)")
+
+        ## print('Generating hilbert with 2^{} {}'.format(m0,m1))
+        #if conf.oneD or conf.twoD:
+        #    hgen = pyrunko.tools.twoD.HilbertGen(int(m0), int(m1))
+        #elif conf.threeD:
+        #    hgen = pyrunko.tools.threeD.HilbertGen(int(m0), int(m1), int(m2) )
+
+        #for i in range(nx):
+        #    for j in range(ny):
+        #        for k in range(nz):
+        #            if conf.oneD or conf.twoD:
+        #                grid[i, j, k] = hgen.hindex(i, j)
+        #            elif conf.threeD:
+        #                grid[i, j, k] = hgen.hindex(i, j, k)
+    
+        #--------------------------------------------------
+        # regular ordering
+        val = 0.0
         for i in range(nx):
             for j in range(ny):
                 for k in range(nz):
-                    if conf.oneD or conf.twoD:
-                        grid[i, j, k] = hgen.hindex(i, j)
-                    elif conf.threeD:
-                        grid[i, j, k] = hgen.hindex(i, j, k)
+                    grid[i, j, k] = val
+                    val += 1.0
 
         print('lba: grid')
         print(grid[:,:,0])
 
-        # print(grid)
         hmin, hmax = np.min(grid), np.max(grid)
 
         # create alternating true grid
@@ -364,8 +375,8 @@ def load_catepillar_track_mpi(
                     ic = i % nx
                     igrid[i, j, k] = np.floor(comm_size * grid[ic, j, k] / (hmax + 1))
 
-        print('lba: full grid')
-        print(igrid[:,:,0])
+        #print('lba: full grid')
+        #print(igrid[:,:,0])
 
         # check that nodes get about same work load
         y = np.bincount(igrid.flatten())
@@ -375,9 +386,9 @@ def load_catepillar_track_mpi(
         tiles_owned = {}
         for (rank, nt) in zip(ii, y[ii]):
             try:
-                tiles_owned[nt] += 1
+                tiles_owned[int(nt)] += 1
             except:
-                tiles_owned[nt] = 1
+                tiles_owned[int(nt)] = 1
         print('lba : tiles owned per rank', tiles_owned, " (#tiles, #ranks)")
 
         for i in range(nxt):

--- a/pytools/scheduler.py
+++ b/pytools/scheduler.py
@@ -9,7 +9,7 @@ def str_to_class(classname):
 
 class Scheduler:
 
-    def __init__(self):
+    def __init__(self, print_banner=True):
         self.timer = None
         self.grid  = None
 
@@ -20,7 +20,7 @@ class Scheduler:
         self.is_master         = True if self.rank == 0 else False # root rank
         self.is_example_worker = True if self.rank == 0 else False # example work rank
 
-        if self.is_master:
+        if self.is_master and print_banner:
             pytools.print_banner()
             print("sch : running runko with {} MPI rank(s)".format(self.mpi_comm_size))
 

--- a/pytools/scheduler.py
+++ b/pytools/scheduler.py
@@ -62,6 +62,8 @@ class Scheduler:
         if self.debug: # additional debug printing
             print('R:', self.rank, op) # debug print
             MPI.COMM_WORLD.Barrier() 
+            if self.is_master:
+                print('',sys.stdout.flush())
     
         #--------------------------------------------------
         # default values
@@ -119,8 +121,8 @@ class Scheduler:
     
             t1 = self.timer.start_comp(op['name'])
     
-            self.grid.send_data(mpid)
             self.grid.recv_data(mpid)
+            self.grid.send_data(mpid)
             self.grid.wait_data(mpid)
     
             self.timer.stop_comp(t1)

--- a/pytools/timer.py
+++ b/pytools/timer.py
@@ -85,11 +85,17 @@ class Timer:
     def stats(self, name):
 
         ts = np.array(self.names[name])
-        cnts = len(ts) - 1
-        if cnts < 1:
-            return
 
-        t0 = ts[-1] - ts[0]
+        if len(ts) == 1: # first time step
+            # obtain duration from summing components instead
+            cnts = 1
+            t0 = 0.0
+            for n in self.components:
+                t0 += np.sum( np.array(self.components[n]) )
+
+        else:
+            t0 = ts[-1] - ts[0]
+            cnts = len(ts) - 1
 
         if self.do_print:
             if t0 < 1.0e-6:
@@ -112,10 +118,15 @@ class Timer:
                 )
 
             # print additional statistics
-            if cnts > 1:
+            if len(ts) == 1: # first time step
+                tavg = t0
+                tstd = 0.0
+            else:
                 tss = self._calc_mean(ts)
                 tavg = np.mean(tss)
                 tstd = np.std(tss)
+
+            if len(ts) > 2:
                 print(
                     "---            avg: {:8.5f} s   /  {:3d}  ({})".format(
                         tavg, cnts, tavg

--- a/tests/test_pic.py
+++ b/tests/test_pic.py
@@ -354,7 +354,7 @@ class PIC(unittest.TestCase):
         fintp  = pyrunko.pic.twoD.LinearInterpolator()
 
 
-        for lap in range(40):
+        for lap in range(20):
 
             for cid in grid.get_local_tiles():
                 tile = grid.get_tile(cid)
@@ -376,26 +376,26 @@ class PIC(unittest.TestCase):
                 tile.check_outgoing_particles()
 
             # global mpi exchange (independent)
-            for cid in grid.get_boundary_tiles():
-                tile = grid.get_tile(cid)
-                tile.pack_outgoing_particles()
+            #for cid in grid.get_boundary_tiles():
+            #    tile = grid.get_tile(cid)
+            #    tile.pack_outgoing_particles()
 
-            # MPI global exchange
-            # transfer primary and extra data
-            grid.send_data(0) #(indepdendent)
-            grid.send_data(1) #(indepdendent)
+            ## MPI global exchange
+            ## transfer primary and extra data
+            #grid.send_data(0) #(indepdendent)
+            #grid.send_data(1) #(indepdendent)
 
-            grid.recv_data(0) #(indepdendent)
-            grid.recv_data(1) #(indepdendent)
+            #grid.recv_data(0) #(indepdendent)
+            #grid.recv_data(1) #(indepdendent)
 
-            grid.wait_data(0) #(indepdendent)
-            grid.wait_data(1) #(indepdendent)
+            #grid.wait_data(0) #(indepdendent)
+            #grid.wait_data(1) #(indepdendent)
 
             # global unpacking (independent)
-            for cid in grid.get_virtual_tiles(): 
-                tile = grid.get_tile(cid)
-                tile.unpack_incoming_particles()
-                tile.check_outgoing_particles()
+            #for cid in grid.get_virtual_tiles(): 
+            #    tile = grid.get_tile(cid)
+            #    tile.unpack_incoming_particles()
+            #    tile.check_outgoing_particles()
 
             # transfer local + global
             for cid in grid.get_local_tiles():
@@ -407,9 +407,10 @@ class PIC(unittest.TestCase):
                 tile = grid.get_tile(cid)
                 tile.delete_transferred_particles()
 
-            for cid in grid.get_virtual_tiles(): 
-                tile = grid.get_tile(cid)
-                tile.delete_all_particles()
+            # delete global mpi particles
+            #for cid in grid.get_virtual_tiles(): 
+            #    tile = grid.get_tile(cid)
+            #    tile.delete_all_particles()
 
         # count how many particles we now have
         n_particles = 0
@@ -481,7 +482,7 @@ class PIC(unittest.TestCase):
         #    axs.append( plt.subplot(gs[ai]) )
 
         conf = Conf()
-        conf.ppc = 128
+        conf.ppc = 16
         conf.threeD = True
         conf.NxMesh = 3
         conf.NyMesh = 3
@@ -578,7 +579,9 @@ class PIC(unittest.TestCase):
                         container = c.get_container(0)
                         #print("({},{},{}) has {}".format(i,j,k,len(container.loc(0))))
                         n_particles += len(container.loc(0))
+                        #n_particles += len(container.size() )
 
+                        #print()
                         #print("num prtcls", i,j,k, "len(loc())", len(container.loc(0)), " cont.size:", container.size())
                         self.assertTrue( len(container.loc(0)) == container.size() )
 

--- a/tests/test_pic.py
+++ b/tests/test_pic.py
@@ -166,77 +166,81 @@ def qudratic_field_3d(x, y, z):
 def insert_em(grid, conf, ffunc, zero_field=False):
 
     Lx  = conf.Nx*conf.NxMesh #XXX scaled length
-    for k in range(grid.get_Nz()):
-        for j in range(grid.get_Ny()):
-            for i in range(grid.get_Nx()):
-                c = grid.get_tile(i,j,k)
-                gs = c.get_grids()
+    #for k in range(grid.get_Nz()):
+    #    for j in range(grid.get_Ny()):
+    #        for i in range(grid.get_Nx()):
 
-                for n in range(conf.NzMesh):
-                    for m in range(conf.NyMesh):
-                        for l in range(conf.NxMesh):
-                            # get x_i,j,k
-                            xloc0 = pytools.ind2loc((i,j,k), (l,m,n), conf)
+    for cid in grid.get_local_tiles():
+        #c = grid.get_tile(i,j,k)
+        c = grid.get_tile(cid)
+        gs = c.get_grids()
+        i,j,k = pytools.get_index(c, conf)
 
-                            #get x_i+1/2, x_j+1/2, x_k+1/2
-                            #xloc1 = pytools.ind2loc((i,j,k), (l+1,m,  n),   conf)
-                            #yloc1 = pytools.ind2loc((i,j,k), (l,  m+1,n),   conf)
-                            #zloc1 = pytools.ind2loc((i,j,k), (l,  m,  n+1), conf)
+        for n in range(conf.NzMesh):
+            for m in range(conf.NyMesh):
+                for l in range(conf.NxMesh):
+                    # get x_i,j,k
+                    xloc0 = pytools.ind2loc((i,j,k), (l,m,n), conf)
 
-                            # values in Yee lattice corners
-                            #xcor = xloc0[0]
-                            #ycor = xloc0[1]
-                            #zcor = xloc0[2]
+                    #get x_i+1/2, x_j+1/2, x_k+1/2
+                    #xloc1 = pytools.ind2loc((i,j,k), (l+1,m,  n),   conf)
+                    #yloc1 = pytools.ind2loc((i,j,k), (l,  m+1,n),   conf)
+                    #zloc1 = pytools.ind2loc((i,j,k), (l,  m,  n+1), conf)
 
-                            # values in Yee lattice mids
-                            #xmid = 0.5*(xloc0[0] + xloc1[0])
-                            #ymid = 0.5*(xloc0[1] + yloc1[1])
-                            #zmid = 0.5*(xloc0[2] + zloc1[2])
+                    # values in Yee lattice corners
+                    #xcor = xloc0[0]
+                    #ycor = xloc0[1]
+                    #zcor = xloc0[2]
 
-                            #val = ffunc(xmid, ymid, zmid)
+                    # values in Yee lattice mids
+                    #xmid = 0.5*(xloc0[0] + xloc1[0])
+                    #ymid = 0.5*(xloc0[1] + yloc1[1])
+                    #zmid = 0.5*(xloc0[2] + zloc1[2])
 
-                            # enforce Yee lattice structure
-                            #gs.ex[l,m,n] = ffunc(xmid, ycor, zcor)
-                            #gs.ey[l,m,n] = ffunc(xcor, ymid, zcor)
-                            #gs.ez[l,m,n] = ffunc(xcor, ycor, zmid)
+                    #val = ffunc(xmid, ymid, zmid)
 
-                            #gs.bx[l,m,n] = ffunc(xcor, ymid, zmid)
-                            #gs.by[l,m,n] = ffunc(xmid, ycor, zmid)
-                            #gs.bz[l,m,n] = ffunc(xmid, ymid, zcor)
+                    # enforce Yee lattice structure
+                    #gs.ex[l,m,n] = ffunc(xmid, ycor, zcor)
+                    #gs.ey[l,m,n] = ffunc(xcor, ymid, zcor)
+                    #gs.ez[l,m,n] = ffunc(xcor, ycor, zmid)
 
-                            #gs.jx[l,m,n] = ffunc(xmid, ymid, zmid)
-                            #gs.jy[l,m,n] = ffunc(xmid, ymid, zmid)
-                            #gs.jz[l,m,n] = ffunc(xmid, ymid, zmid)
+                    #gs.bx[l,m,n] = ffunc(xcor, ymid, zmid)
+                    #gs.by[l,m,n] = ffunc(xmid, ycor, zmid)
+                    #gs.bz[l,m,n] = ffunc(xmid, ymid, zcor)
 
-                            #TODO
-                            xc = xloc0[0]
-                            yc = xloc0[1]
-                            zc = xloc0[2]
-                            #gs.ex[l,m,n] = ffunc(xc,yc-0.5,zc-0.5)
-                            #gs.ey[l,m,n] = ffunc(xc-0.5,yc,zc-0.5)
-                            #gs.ez[l,m,n] = ffunc(xc-0.5,yc-0.5,zc)
-                            #gs.bx[l,m,n] = ffunc(xc-0.5,yc,zc)
-                            #gs.by[l,m,n] = ffunc(xc,yc-0.5,zc)
-                            #gs.bz[l,m,n] = ffunc(xc,yc,zc-0.5)
+                    #gs.jx[l,m,n] = ffunc(xmid, ymid, zmid)
+                    #gs.jy[l,m,n] = ffunc(xmid, ymid, zmid)
+                    #gs.jz[l,m,n] = ffunc(xmid, ymid, zmid)
 
-                            gs.ex[l,m,n] = ffunc(xc+0.5,yc,    zc)
-                            gs.ey[l,m,n] = ffunc(xc,    yc+0.5,zc)
-                            gs.ez[l,m,n] = ffunc(xc,    yc,    zc+0.5)
-                            gs.bx[l,m,n] = ffunc(xc,    yc+0.5,zc+0.5)
-                            gs.by[l,m,n] = ffunc(xc+0.5,yc,    zc+0.5)
-                            gs.bz[l,m,n] = ffunc(xc+0.5,yc+0.5,zc)
+                    #TODO
+                    xc = xloc0[0]
+                    yc = xloc0[1]
+                    zc = xloc0[2]
+                    #gs.ex[l,m,n] = ffunc(xc,yc-0.5,zc-0.5)
+                    #gs.ey[l,m,n] = ffunc(xc-0.5,yc,zc-0.5)
+                    #gs.ez[l,m,n] = ffunc(xc-0.5,yc-0.5,zc)
+                    #gs.bx[l,m,n] = ffunc(xc-0.5,yc,zc)
+                    #gs.by[l,m,n] = ffunc(xc,yc-0.5,zc)
+                    #gs.bz[l,m,n] = ffunc(xc,yc,zc-0.5)
 
-                            gs.jx[l,m,n] = ffunc(xc,yc,zc)
-                            gs.jy[l,m,n] = ffunc(xc,yc,zc)
-                            gs.jz[l,m,n] = ffunc(xc,yc,zc)
+                    gs.ex[l,m,n] = ffunc(xc+0.5,yc,    zc)
+                    gs.ey[l,m,n] = ffunc(xc,    yc+0.5,zc)
+                    gs.ez[l,m,n] = ffunc(xc,    yc,    zc+0.5)
+                    gs.bx[l,m,n] = ffunc(xc,    yc+0.5,zc+0.5)
+                    gs.by[l,m,n] = ffunc(xc+0.5,yc,    zc+0.5)
+                    gs.bz[l,m,n] = ffunc(xc+0.5,yc+0.5,zc)
 
-                            if not(zero_field):
-                                gs.ex[l,m,n] += +0.0
-                                gs.ey[l,m,n] += +1.0
-                                gs.ez[l,m,n] += +2.0 
-                                gs.bx[l,m,n] += +3.0
-                                gs.by[l,m,n] += +4.0
-                                gs.bz[l,m,n] += +5.0
+                    gs.jx[l,m,n] = ffunc(xc,yc,zc)
+                    gs.jy[l,m,n] = ffunc(xc,yc,zc)
+                    gs.jz[l,m,n] = ffunc(xc,yc,zc)
+
+                    if not(zero_field):
+                        gs.ex[l,m,n] += +0.0
+                        gs.ey[l,m,n] += +1.0
+                        gs.ez[l,m,n] += +2.0 
+                        gs.bx[l,m,n] += +3.0
+                        gs.by[l,m,n] += +4.0
+                        gs.bz[l,m,n] += +5.0
 
 
 
@@ -285,6 +289,7 @@ class Conf:
     qe = 1.0
     qi =-1.0
 
+    oneD   = False
     twoD   = False
     threeD = False
 
@@ -414,50 +419,52 @@ class PIC(unittest.TestCase):
 
         # count how many particles we now have
         n_particles = 0
-        for i in range(conf.Nx):
-            for j in range(conf.Ny):
-                for k in range(conf.Nz):
-                    cid = grid.id(i,j)
-                    c = grid.get_tile(cid)
+        #for i in range(conf.Nx):
+        #    for j in range(conf.Ny):
+        #        for k in range(conf.Nz):
+        #    cid = grid.id(i,j)
+        for cid in grid.get_local_tiles():
+            c = grid.get_tile(cid)
+            i,j,k = pytools.get_index(c, conf)
 
-                    container = c.get_container(0)
-                    #print("({},{},{}) has {}".format(i,j,k,len(container.loc(0))))
-                    n_particles += len(container.loc(0))
+            container = c.get_container(0)
+            #print("({},{},{}) has {}".format(i,j,k,len(container.loc(0))))
+            n_particles += len(container.loc(0))
 
-                    #self.assertTrue( 0.0 <= container.loc(0) <= conf.xmax )
-                    #self.assertTrue( 0.0 <= container.loc(1) <= conf.ymax )
-                    #self.assertTrue( 0.0 <= container.loc(2) <= conf.zmax )
+            #self.assertTrue( 0.0 <= container.loc(0) <= conf.xmax )
+            #self.assertTrue( 0.0 <= container.loc(1) <= conf.ymax )
+            #self.assertTrue( 0.0 <= container.loc(2) <= conf.zmax )
 
-                    for prtcl in range(len(container.loc(0))):
-                        #print("{} {} {} maxs {} {} {} id {}/{}".format( 
-                        #container.loc(0)[prtcl], 
-                        #container.loc(1)[prtcl], 
-                        #container.loc(2)[prtcl], 
-                        #conf.xmax, conf.ymax, conf.zmax, 
-                        #container.id(0)[prtcl], 
-                        #container.id(1)[prtcl], 
-                        #))
+            for prtcl in range(len(container.loc(0))):
+                #print("{} {} {} maxs {} {} {} id {}/{}".format( 
+                #container.loc(0)[prtcl], 
+                #container.loc(1)[prtcl], 
+                #container.loc(2)[prtcl], 
+                #conf.xmax, conf.ymax, conf.zmax, 
+                #container.id(0)[prtcl], 
+                #container.id(1)[prtcl], 
+                #))
 
-                        #print("prtcl {} x={} y={} z={} vx={} vy={} vz={}".format(
-                        #    prtcl, 
-                        #    container.loc(0)[prtcl],
-                        #    container.loc(1)[prtcl],
-                        #    container.loc(2)[prtcl],
-                        #    container.vel(0)[prtcl],
-                        #    container.vel(1)[prtcl],
-                        #    container.vel(2)[prtcl]))
+                #print("prtcl {} x={} y={} z={} vx={} vy={} vz={}".format(
+                #    prtcl, 
+                #    container.loc(0)[prtcl],
+                #    container.loc(1)[prtcl],
+                #    container.loc(2)[prtcl],
+                #    container.vel(0)[prtcl],
+                #    container.vel(1)[prtcl],
+                #    container.vel(2)[prtcl]))
 
-                        # check location
-                        self.assertTrue( 0.0 <= container.loc(0)[prtcl] <= conf.xmax )
-                        self.assertTrue( 0.0 <= container.loc(1)[prtcl] <= conf.ymax )
-                        self.assertTrue( 0.0 <= container.loc(2)[prtcl] <= conf.zmax )
+                # check location
+                self.assertTrue( 0.0 <= container.loc(0)[prtcl] <= conf.xmax )
+                self.assertTrue( 0.0 <= container.loc(1)[prtcl] <= conf.ymax )
+                self.assertTrue( 0.0 <= container.loc(2)[prtcl] <= conf.zmax )
 
-                        # check velocity 
-                        velx = container.vel(0)[prtcl]
-                        vely = container.vel(1)[prtcl]
-                        velz = container.vel(2)[prtcl]
-                        vel = np.sqrt( velx*velx + vely*vely + velz*velz )
-                        self.assertAlmostEqual( vel, conf.vel, places=5 )
+                # check velocity 
+                velx = container.vel(0)[prtcl]
+                vely = container.vel(1)[prtcl]
+                velz = container.vel(2)[prtcl]
+                vel = np.sqrt( velx*velx + vely*vely + velz*velz )
+                self.assertAlmostEqual( vel, conf.vel, places=5 )
 
         tot_particles = (conf.Nx*conf.NxMesh *
                         conf.Ny*conf.NyMesh *
@@ -529,26 +536,26 @@ class PIC(unittest.TestCase):
                 tile.check_outgoing_particles()
 
             # global mpi exchange (independent)
-            #for cid in grid.get_boundary_tiles():
-            #    tile = grid.get_tile(cid)
-            #    tile.pack_outgoing_particles()
+            for cid in grid.get_boundary_tiles():
+                tile = grid.get_tile(cid)
+                tile.pack_outgoing_particles()
 
             # MPI global exchange
             # transfer primary and extra data
-            #grid.recv_data(0) #(indepdendent)
-            #grid.recv_data(1) #(indepdendent)
+            grid.recv_data(0) #(indepdendent)
+            grid.recv_data(1) #(indepdendent)
 
-            #grid.send_data(0) #(indepdendent)
-            #grid.send_data(1) #(indepdendent)
+            grid.send_data(0) #(indepdendent)
+            grid.send_data(1) #(indepdendent)
 
-            #grid.wait_data(0) #(indepdendent)
-            #grid.wait_data(1) #(indepdendent)
+            grid.wait_data(0) #(indepdendent)
+            grid.wait_data(1) #(indepdendent)
 
             # global unpacking (independent)
-            #for cid in grid.get_virtual_tiles(): 
-            #    tile = grid.get_tile(cid)
-            #    tile.unpack_incoming_particles()
-            #    tile.check_outgoing_particles()
+            for cid in grid.get_virtual_tiles(): 
+                tile = grid.get_tile(cid)
+                tile.unpack_incoming_particles()
+                tile.check_outgoing_particles()
 
             # transfer local + global
             for cid in grid.get_local_tiles():
@@ -560,9 +567,10 @@ class PIC(unittest.TestCase):
                 tile = grid.get_tile(cid)
                 tile.delete_transferred_particles()
 
-            #for cid in grid.get_virtual_tiles(): 
-            #    tile = grid.get_tile(cid)
-            #    tile.delete_all_particles()
+            for cid in grid.get_virtual_tiles(): 
+                tile = grid.get_tile(cid)
+                tile.delete_all_particles()
+
 
             # outflow 26   8.30763             5.59324             9.03402              2.30763                -0.406764               3.03402   mins:6 3 6 maxs:9 6 9
             #prtcl    22 x=8.307631492614746 y=5.593235969543457 z=9.03402328491211 vx=-0.020194780081510544 vy=0.23969225585460663 vz=0.1792757362127304 | tile lims 9 9 9
@@ -570,59 +578,60 @@ class PIC(unittest.TestCase):
             # count how many particles we now have
             n_particles = 0
             #for cid in grid.get_local_tiles():
-            for i in range(conf.Nx):
-                for j in range(conf.Ny):
-                    for k in range(conf.Nz):
-                        cid = grid.id(i,j,k)
-                        c = grid.get_tile(cid)
+            #for i in range(conf.Nx):
+            #    for j in range(conf.Ny):
+            #        for k in range(conf.Nz):
+            for cid in grid.get_local_tiles():
+                c = grid.get_tile(cid)
+                i,j,k = pytools.get_index(c, conf)
 
-                        container = c.get_container(0)
-                        #print("({},{},{}) has {}".format(i,j,k,len(container.loc(0))))
-                        n_particles += len(container.loc(0))
-                        #n_particles += len(container.size() )
+                container = c.get_container(0)
+                #print("({},{},{}) has {}".format(i,j,k,len(container.loc(0))))
+                n_particles += len(container.loc(0))
+                #n_particles += len(container.size() )
 
-                        #print()
-                        #print("num prtcls", i,j,k, "len(loc())", len(container.loc(0)), " cont.size:", container.size())
-                        self.assertTrue( len(container.loc(0)) == container.size() )
+                #print()
+                #print("num prtcls", i,j,k, "len(loc())", len(container.loc(0)), " cont.size:", container.size())
+                self.assertTrue( len(container.loc(0)) == container.size() )
 
-                        #self.assertTrue( 0.0 <= container.loc(0) <= conf.xmax )
-                        #self.assertTrue( 0.0 <= container.loc(1) <= conf.ymax )
-                        #self.assertTrue( 0.0 <= container.loc(2) <= conf.zmax )
+                #self.assertTrue( 0.0 <= container.loc(0) <= conf.xmax )
+                #self.assertTrue( 0.0 <= container.loc(1) <= conf.ymax )
+                #self.assertTrue( 0.0 <= container.loc(2) <= conf.zmax )
 
-                        for prtcl in range(len(container.loc(0))):
-                            #print("{} {} {} maxs {} {} {} id {}/{}".format( 
-                            #container.loc(0)[prtcl], 
-                            #container.loc(1)[prtcl], 
-                            #container.loc(2)[prtcl], 
-                            #conf.xmax, conf.ymax, conf.zmax, 
-                            #container.id(0)[prtcl], 
-                            #container.id(1)[prtcl], 
-                            #))
+                for prtcl in range(len(container.loc(0))):
+                    #print("{} {} {} maxs {} {} {} id {}/{}".format( 
+                    #container.loc(0)[prtcl], 
+                    #container.loc(1)[prtcl], 
+                    #container.loc(2)[prtcl], 
+                    #conf.xmax, conf.ymax, conf.zmax, 
+                    #container.id(0)[prtcl], 
+                    #container.id(1)[prtcl], 
+                    #))
 
-                            #print("prtcl {} x={} y={} z={} vx={} vy={} vz={} w={} | tile lims {} {} {}".format(
-                            #    prtcl, 
-                            #    container.loc(0)[prtcl],
-                            #    container.loc(1)[prtcl],
-                            #    container.loc(2)[prtcl],
-                            #    container.vel(0)[prtcl],
-                            #    container.vel(1)[prtcl],
-                            #    container.vel(2)[prtcl],
-                            #    container.wgt()[ prtcl],
-                            #    conf.xmax,
-                            #    conf.ymax,
-                            #    conf.zmax),)
+                    #print("prtcl {} x={} y={} z={} vx={} vy={} vz={} w={} | tile lims {} {} {}".format(
+                    #    prtcl, 
+                    #    container.loc(0)[prtcl],
+                    #    container.loc(1)[prtcl],
+                    #    container.loc(2)[prtcl],
+                    #    container.vel(0)[prtcl],
+                    #    container.vel(1)[prtcl],
+                    #    container.vel(2)[prtcl],
+                    #    container.wgt()[ prtcl],
+                    #    conf.xmax,
+                    #    conf.ymax,
+                    #    conf.zmax),)
 
-                            # check location
-                            self.assertTrue( 0.0 <= container.loc(0)[prtcl] <= conf.xmax )
-                            self.assertTrue( 0.0 <= container.loc(1)[prtcl] <= conf.ymax )
-                            self.assertTrue( 0.0 <= container.loc(2)[prtcl] <= conf.zmax )
+                    # check location
+                    self.assertTrue( 0.0 <= container.loc(0)[prtcl] <= conf.xmax )
+                    self.assertTrue( 0.0 <= container.loc(1)[prtcl] <= conf.ymax )
+                    self.assertTrue( 0.0 <= container.loc(2)[prtcl] <= conf.zmax )
 
-                            # check velocity 
-                            velx = container.vel(0)[prtcl]
-                            vely = container.vel(1)[prtcl]
-                            velz = container.vel(2)[prtcl]
-                            vel = np.sqrt( velx*velx + vely*vely + velz*velz )
-                            self.assertAlmostEqual( vel, conf.vel, places=5 )
+                    # check velocity 
+                    velx = container.vel(0)[prtcl]
+                    vely = container.vel(1)[prtcl]
+                    velz = container.vel(2)[prtcl]
+                    vel = np.sqrt( velx*velx + vely*vely + velz*velz )
+                    self.assertAlmostEqual( vel, conf.vel, places=5 )
 
             tot_particles = (conf.Nx*conf.NxMesh *
                              conf.Ny*conf.NyMesh *
@@ -650,10 +659,9 @@ class PIC(unittest.TestCase):
         pytools.pic.inject(grid, filler_no_velocity, density_profile, conf) #pytools.pic.injecting plasma particles
 
         ##update boundaries
-        for j in range(grid.get_Ny()):
-            for i in range(grid.get_Nx()):
-                tile = grid.get_tile(i,j)
-                tile.update_boundaries(grid)
+        for cid in grid.get_local_tiles():
+            tile = grid.get_tile(cid)
+            tile.update_boundaries(grid)
 
         #interpolate emf
         fintps = []
@@ -662,42 +670,38 @@ class PIC(unittest.TestCase):
         fintps.append( pyrunko.pic.twoD.QuadraticInterpolator() )
 
         for fintp in fintps:
-            for j in range(grid.get_Ny()):
-                for i in range(grid.get_Nx()):
-                    tile = grid.get_tile(i,j)
-                    fintp.solve(tile)
+            for cid in grid.get_local_tiles():
+                tile = grid.get_tile(cid)
+                fintp.solve(tile)
 
             #test results
-            for i in range(conf.Nx):
-                for j in range(conf.Ny):
+            for cid in grid.get_local_tiles():
+                c = grid.get_tile(cid)
+                container = c.get_container(0)
 
-                    cid = grid.id(i,j)
-                    c = grid.get_tile(cid)
-                    container = c.get_container(0)
+                xx = container.loc(0)
+                yy = container.loc(1)
+                zz = container.loc(2)
 
-                    xx = container.loc(0)
-                    yy = container.loc(1)
-                    zz = container.loc(2)
+                ux = container.vel(0)
+                uy = container.vel(1)
+                uz = container.vel(2)
 
-                    ux = container.vel(0)
-                    uy = container.vel(1)
-                    uz = container.vel(2)
+                for i, x in enumerate(xx):
+                    #print(i)
+                    ex_ref = 1.0
+                    ey_ref = 2.0
+                    ez_ref = 3.0
+                    self.assertAlmostEqual(container.ex(i), ex_ref, places=5)
+                    self.assertAlmostEqual(container.ey(i), ey_ref, places=5)
+                    self.assertAlmostEqual(container.ez(i), ez_ref, places=5)
 
-                    for i, x in enumerate(xx):
-                        #print(i)
-                        ex_ref = 1.0
-                        ey_ref = 2.0
-                        ez_ref = 3.0
-                        self.assertAlmostEqual(container.ex(i), ex_ref, places=5)
-                        self.assertAlmostEqual(container.ey(i), ey_ref, places=5)
-                        self.assertAlmostEqual(container.ez(i), ez_ref, places=5)
-
-                        bx_ref = 4.0
-                        by_ref = 5.0
-                        bz_ref = 6.0
-                        self.assertAlmostEqual(container.bx(i), bx_ref, places=5)
-                        self.assertAlmostEqual(container.by(i), by_ref, places=5)
-                        self.assertAlmostEqual(container.bz(i), bz_ref, places=5)
+                    bx_ref = 4.0
+                    by_ref = 5.0
+                    bz_ref = 6.0
+                    self.assertAlmostEqual(container.bx(i), bx_ref, places=5)
+                    self.assertAlmostEqual(container.by(i), by_ref, places=5)
+                    self.assertAlmostEqual(container.bz(i), bz_ref, places=5)
 
 
     def test_const_field_interpolation_3d(self):

--- a/tests/test_pic.py
+++ b/tests/test_pic.py
@@ -533,11 +533,11 @@ class PIC(unittest.TestCase):
 
             # MPI global exchange
             # transfer primary and extra data
-            grid.send_data(0) #(indepdendent)
-            grid.send_data(1) #(indepdendent)
-
             grid.recv_data(0) #(indepdendent)
             grid.recv_data(1) #(indepdendent)
+
+            grid.send_data(0) #(indepdendent)
+            grid.send_data(1) #(indepdendent)
 
             grid.wait_data(0) #(indepdendent)
             grid.wait_data(1) #(indepdendent)

--- a/tests/test_pic.py
+++ b/tests/test_pic.py
@@ -481,6 +481,7 @@ class PIC(unittest.TestCase):
         #    axs.append( plt.subplot(gs[ai]) )
 
         conf = Conf()
+        conf.ppc = 128
         conf.threeD = True
         conf.NxMesh = 3
         conf.NyMesh = 3
@@ -505,7 +506,7 @@ class PIC(unittest.TestCase):
 
         fintp  = pyrunko.pic.threeD.LinearInterpolator()
 
-        for lap in range(40):
+        for lap in range(2):
 
             for cid in grid.get_local_tiles():
                 tile = grid.get_tile(cid)
@@ -527,26 +528,26 @@ class PIC(unittest.TestCase):
                 tile.check_outgoing_particles()
 
             # global mpi exchange (independent)
-            for cid in grid.get_boundary_tiles():
-                tile = grid.get_tile(cid)
-                tile.pack_outgoing_particles()
+            #for cid in grid.get_boundary_tiles():
+            #    tile = grid.get_tile(cid)
+            #    tile.pack_outgoing_particles()
 
             # MPI global exchange
             # transfer primary and extra data
-            grid.recv_data(0) #(indepdendent)
-            grid.recv_data(1) #(indepdendent)
+            #grid.recv_data(0) #(indepdendent)
+            #grid.recv_data(1) #(indepdendent)
 
-            grid.send_data(0) #(indepdendent)
-            grid.send_data(1) #(indepdendent)
+            #grid.send_data(0) #(indepdendent)
+            #grid.send_data(1) #(indepdendent)
 
-            grid.wait_data(0) #(indepdendent)
-            grid.wait_data(1) #(indepdendent)
+            #grid.wait_data(0) #(indepdendent)
+            #grid.wait_data(1) #(indepdendent)
 
             # global unpacking (independent)
-            for cid in grid.get_virtual_tiles(): 
-                tile = grid.get_tile(cid)
-                tile.unpack_incoming_particles()
-                tile.check_outgoing_particles()
+            #for cid in grid.get_virtual_tiles(): 
+            #    tile = grid.get_tile(cid)
+            #    tile.unpack_incoming_particles()
+            #    tile.check_outgoing_particles()
 
             # transfer local + global
             for cid in grid.get_local_tiles():
@@ -558,69 +559,80 @@ class PIC(unittest.TestCase):
                 tile = grid.get_tile(cid)
                 tile.delete_transferred_particles()
 
-            for cid in grid.get_virtual_tiles(): 
-                tile = grid.get_tile(cid)
-                tile.delete_all_particles()
+            #for cid in grid.get_virtual_tiles(): 
+            #    tile = grid.get_tile(cid)
+            #    tile.delete_all_particles()
 
-        # count how many particles we now have
-        n_particles = 0
-        for i in range(conf.Nx):
-            for j in range(conf.Ny):
-                for k in range(conf.Nz):
-                    cid = grid.id(i,j,k)
-                    c = grid.get_tile(cid)
+            # outflow 26   8.30763             5.59324             9.03402              2.30763                -0.406764               3.03402   mins:6 3 6 maxs:9 6 9
+            #prtcl    22 x=8.307631492614746 y=5.593235969543457 z=9.03402328491211 vx=-0.020194780081510544 vy=0.23969225585460663 vz=0.1792757362127304 | tile lims 9 9 9
 
-                    container = c.get_container(0)
-                    #print("({},{},{}) has {}".format(i,j,k,len(container.loc(0))))
-                    n_particles += len(container.loc(0))
+            # count how many particles we now have
+            n_particles = 0
+            #for cid in grid.get_local_tiles():
+            for i in range(conf.Nx):
+                for j in range(conf.Ny):
+                    for k in range(conf.Nz):
+                        cid = grid.id(i,j,k)
+                        c = grid.get_tile(cid)
 
-                    #self.assertTrue( 0.0 <= container.loc(0) <= conf.xmax )
-                    #self.assertTrue( 0.0 <= container.loc(1) <= conf.ymax )
-                    #self.assertTrue( 0.0 <= container.loc(2) <= conf.zmax )
+                        container = c.get_container(0)
+                        #print("({},{},{}) has {}".format(i,j,k,len(container.loc(0))))
+                        n_particles += len(container.loc(0))
 
-                    for prtcl in range(len(container.loc(0))):
-                        #print("{} {} {} maxs {} {} {} id {}/{}".format( 
-                        #container.loc(0)[prtcl], 
-                        #container.loc(1)[prtcl], 
-                        #container.loc(2)[prtcl], 
-                        #conf.xmax, conf.ymax, conf.zmax, 
-                        #container.id(0)[prtcl], 
-                        #container.id(1)[prtcl], 
-                        #))
+                        #print("num prtcls", i,j,k, "len(loc())", len(container.loc(0)), " cont.size:", container.size())
+                        self.assertTrue( len(container.loc(0)) == container.size() )
 
-                        #print("prtcl {} x={} y={} z={} vx={} vy={} vz={}".format(
-                        #    prtcl, 
-                        #    container.loc(0)[prtcl],
-                        #    container.loc(1)[prtcl],
-                        #    container.loc(2)[prtcl],
-                        #    container.vel(0)[prtcl],
-                        #    container.vel(1)[prtcl],
-                        #    container.vel(2)[prtcl]))
+                        #self.assertTrue( 0.0 <= container.loc(0) <= conf.xmax )
+                        #self.assertTrue( 0.0 <= container.loc(1) <= conf.ymax )
+                        #self.assertTrue( 0.0 <= container.loc(2) <= conf.zmax )
 
-                        # check location
-                        self.assertTrue( 0.0 <= container.loc(0)[prtcl] <= conf.xmax )
-                        self.assertTrue( 0.0 <= container.loc(1)[prtcl] <= conf.ymax )
-                        self.assertTrue( 0.0 <= container.loc(2)[prtcl] <= conf.zmax )
+                        for prtcl in range(len(container.loc(0))):
+                            #print("{} {} {} maxs {} {} {} id {}/{}".format( 
+                            #container.loc(0)[prtcl], 
+                            #container.loc(1)[prtcl], 
+                            #container.loc(2)[prtcl], 
+                            #conf.xmax, conf.ymax, conf.zmax, 
+                            #container.id(0)[prtcl], 
+                            #container.id(1)[prtcl], 
+                            #))
 
-                        # check velocity 
-                        velx = container.vel(0)[prtcl]
-                        vely = container.vel(1)[prtcl]
-                        velz = container.vel(2)[prtcl]
-                        vel = np.sqrt( velx*velx + vely*vely + velz*velz )
-                        self.assertAlmostEqual( vel, conf.vel, places=5 )
+                            #print("prtcl {} x={} y={} z={} vx={} vy={} vz={} w={} | tile lims {} {} {}".format(
+                            #    prtcl, 
+                            #    container.loc(0)[prtcl],
+                            #    container.loc(1)[prtcl],
+                            #    container.loc(2)[prtcl],
+                            #    container.vel(0)[prtcl],
+                            #    container.vel(1)[prtcl],
+                            #    container.vel(2)[prtcl],
+                            #    container.wgt()[ prtcl],
+                            #    conf.xmax,
+                            #    conf.ymax,
+                            #    conf.zmax),)
 
-        tot_particles = (conf.Nx*conf.NxMesh *
-                         conf.Ny*conf.NyMesh *
-                         conf.Nz*conf.NzMesh *
-                        conf.ppc)
+                            # check location
+                            self.assertTrue( 0.0 <= container.loc(0)[prtcl] <= conf.xmax )
+                            self.assertTrue( 0.0 <= container.loc(1)[prtcl] <= conf.ymax )
+                            self.assertTrue( 0.0 <= container.loc(2)[prtcl] <= conf.zmax )
 
-        #tot_particles =(conf.NxMesh *
-        #                conf.NyMesh *
-        #                conf.NzMesh *
-        #                conf.ppc)
+                            # check velocity 
+                            velx = container.vel(0)[prtcl]
+                            vely = container.vel(1)[prtcl]
+                            velz = container.vel(2)[prtcl]
+                            vel = np.sqrt( velx*velx + vely*vely + velz*velz )
+                            self.assertAlmostEqual( vel, conf.vel, places=5 )
 
-        # assert that there is equal number of particles as we began with
-        self.assertEqual( tot_particles, n_particles )
+            tot_particles = (conf.Nx*conf.NxMesh *
+                             conf.Ny*conf.NyMesh *
+                             conf.Nz*conf.NzMesh *
+                            conf.ppc)
+
+            #tot_particles =(conf.NxMesh *
+            #                conf.NyMesh *
+            #                conf.NzMesh *
+            #                conf.ppc)
+
+            # assert that there is equal number of particles as we began with
+            self.assertEqual( tot_particles, n_particles )
 
 
 


### PR DESCRIPTION
Vectorization breaks the MPI particle communication routines, deletion routines, and outflow detection routines. This PR fixes these by more rigorously selecting vectorized/non-vectorized loops. 

Tested w/ GCC + OpenMPI and Cray+MPICH dev packs.

